### PR TITLE
feat/#11 set frontend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,39 @@
+# ========================================
+# Payment Demo Environment Variables
+# ========================================
+# 사용 방법:
+# 1. 이 파일을 복사해서 `.env` 파일을 만듭니다.
+# 2. 각 항목에 실제 운영/개발 값을 입력합니다.
+# 3. `.env` 파일은 커밋하지 않고, `.env.example`만 공유합니다.
+
+# ========================================
+# PortOne API Configuration
+# ========================================
+# PortOne REST API Secret
+# 예시: portone_v1_xxxxxxxxxxxxxxxxxxxx
+PORTONE_API_SECRET=
+
+# PortOne 상점(Store) ID
+# 예시: store-12345678-1234-1234-1234-123456789abc
+PORTONE_STORE_ID=
+
+# PortOne KG Inicis 채널 키
+# 예시: channel-key-kg-inicis-xxxxxxxx
+PORTONE_CHANNEL_KG=
+
+# PortOne Toss Payments 채널 키
+# 예시: channel-key-toss-xxxxxxxx
+PORTONE_CHANNEL_TOSS=
+
+# ========================================
+# JWT Configuration
+# ========================================
+# JWT 서명용 시크릿 키
+# 충분히 길고 예측 불가능한 문자열을 사용하세요.
+# 예시: L6h/xMxGO53HQmR/OB99qR/y0kTr2CAyaI5RqBIX184=
+JWT_SECRET=
+
+# JWT 만료 시간(초)
+# 기본값: 86400 (24시간)
+JWT_VALIDITY=86400
+

--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,6 @@ bin/
 Thumbs.db
 
 # Application
-application-local.yml
 application-secret.yml
 
 # Logs

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ logs/
 *.bak
 *.swp
 *~
+
+# Environment Variables
+.env

--- a/README.md
+++ b/README.md
@@ -52,7 +52,40 @@
 
 ## 🚀 빠른 시작
 
-### 1. 프로젝트 실행
+### 1. 환경변수 파일 준비
+
+이 프로젝트는 루트 경로의 `.env` 파일을 시작 시 자동으로 로드합니다.
+
+```bash
+# 예시 파일 복사
+cp .env.example .env
+```
+
+`.env`에는 `application.yml`에서 사용하는 외부 설정 값을 넣습니다.
+
+```env
+PORTONE_API_SECRET=
+PORTONE_STORE_ID=
+PORTONE_CHANNEL_KG=
+PORTONE_CHANNEL_TOSS=
+JWT_SECRET=
+JWT_VALIDITY=86400
+```
+
+**설명:**
+- `PORTONE_API_SECRET`: PortOne REST API Secret
+- `PORTONE_STORE_ID`: PortOne Store ID
+- `PORTONE_CHANNEL_KG`: 일반 결제용 KG Inicis 채널 키
+- `PORTONE_CHANNEL_TOSS`: 구독/빌링키용 Toss 채널 키
+- `JWT_SECRET`: JWT 서명용 시크릿 키
+- `JWT_VALIDITY`: JWT 만료 시간(초), 기본값 `86400`
+
+**주의사항:**
+- `.env.example`은 예시 템플릿이며, 실제 비밀값은 `.env`에만 입력하세요.
+- `.env`는 `.gitignore`에 포함되어 있어 Git에 커밋되지 않습니다.
+- `.env` 파일이 없어도 애플리케이션은 실행되지만, `application.yml`의 기본값이 사용됩니다.
+
+### 2. 프로젝트 실행
 
 ```bash
 # Gradle로 실행
@@ -62,13 +95,13 @@
 # PaymentDemoApplication.java 메인 클래스 실행
 ```
 
-### 2. 브라우저 접속
+### 3. 브라우저 접속
 
 ```
 http://localhost:8080
 ```
 
-### 3. 기본 계정 (Spring Security)
+### 4. 기본 계정 (Spring Security)
 
 현재 데모 버전에서는 별도 로그인 없이 사용 가능합니다.
 
@@ -123,7 +156,30 @@ src/
 
 ## ⚙️ 설정 가이드
 
-### 1. PortOne 설정
+### 1. 환경변수 기반 설정
+
+`src/main/resources/application.yml`은 다음 값을 환경변수에서 읽습니다:
+
+```yaml
+portone:
+  api:
+    secret: ${PORTONE_API_SECRET:your-api-secret}
+  store:
+    id: ${PORTONE_STORE_ID:your-store-id}
+  channel:
+    kg-inicis: ${PORTONE_CHANNEL_KG:your-kg-inicis-channel-key}
+    toss: ${PORTONE_CHANNEL_TOSS:your-toss-channel-key}
+
+jwt:
+  secret: ${JWT_SECRET:commercehub-secret-key-for-demo-please-change-this-in-production-environment}
+  token-validity-in-seconds: ${JWT_VALIDITY:86400}
+```
+
+로컬 개발 시에는 프로젝트 루트의 `.env` 파일을 사용하면 됩니다.
+
+---
+
+### 2. PortOne 설정
 
 `src/main/resources/application.yml` 파일에서 PortOne 정보를 설정합니다:
 
@@ -146,7 +202,7 @@ portone:
 
 ---
 
-### 2. API 계약 설정 (가장 중요!)
+### 3. API 계약 설정 (가장 중요!)
 
 `src/main/resources/client-api-config.yml` 파일에서 API 계약을 정의합니다.
 
@@ -221,7 +277,7 @@ const url = await buildApiUrl('confirm-payment', { paymentId: 'pay_123' });
 
 ---
 
-### 3. 동적 API 목록 표시
+### 4. 동적 API 목록 표시
 
 각 페이지는 필요한 API 목록을 `client-api-config.yml`에서 동적으로 읽어와 화면에 표시합니다.
 

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,11 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
 
     // h2 database
+    implementation 'org.springframework.boot:spring-boot-h2console'
     runtimeOnly 'com.h2database:h2'
+
+    // MySQL database
+    runtimeOnly 'com.mysql:mysql-connector-j'
 
     // Configuration Properties
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'

--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,9 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // Environment Variables
+    implementation 'io.github.cdimascio:dotenv-java:3.0.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/bootcamp/paymentdemo/PaymentDemoApplication.java
+++ b/src/main/java/com/bootcamp/paymentdemo/PaymentDemoApplication.java
@@ -1,5 +1,6 @@
 package com.bootcamp.paymentdemo;
 
+import com.bootcamp.paymentdemo.common.config.DotenvInitializer;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
@@ -11,6 +12,8 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 public class PaymentDemoApplication {
 
     public static void main(String[] args) {
-        SpringApplication.run(PaymentDemoApplication.class, args);
+        SpringApplication app = new SpringApplication(PaymentDemoApplication.class);
+        app.addInitializers(new DotenvInitializer());
+        app.run(args);
     }
 }

--- a/src/main/java/com/bootcamp/paymentdemo/common/config/DotenvInitializer.java
+++ b/src/main/java/com/bootcamp/paymentdemo/common/config/DotenvInitializer.java
@@ -1,0 +1,37 @@
+package com.bootcamp.paymentdemo.common.config;
+
+
+import io.github.cdimascio.dotenv.Dotenv;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+public class DotenvInitializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+    @Override
+    public void initialize(ConfigurableApplicationContext applicationContext) {
+        try {
+            // .env 파일 로드 (파일이 없으면 무시)
+            Dotenv dotenv = Dotenv.configure()
+                    .ignoreIfMissing()
+                    .load();
+
+            Map<String, Object> dotenvMap = new HashMap<>();
+
+            // .env 파일의 모든 key-value를 Map에 저장
+            dotenv.entries().forEach(entry -> dotenvMap.put(entry.getKey(), entry.getValue()));
+
+            // 스프링 Environment에 등록 (우선순위를 높게 설정)
+            ConfigurableEnvironment environment = applicationContext.getEnvironment();
+            environment.getPropertySources().addFirst(new MapPropertySource("dotenv", dotenvMap));
+        } catch (Exception e) {
+            // .env 파일이 없거나 로드할 수 없는 경우 무시
+            log.info("INFO: .env file not found or could not be loaded. Using default configuration.");
+        }
+    }
+}

--- a/src/main/java/com/bootcamp/paymentdemo/common/config/SecurityConfig.java
+++ b/src/main/java/com/bootcamp/paymentdemo/common/config/SecurityConfig.java
@@ -1,6 +1,5 @@
 package com.bootcamp.paymentdemo.common.config;
 
-import com.bootcamp.paymentdemo.security.JwtAuthenticationFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -9,6 +8,7 @@ import org.springframework.security.config.annotation.authentication.configurati
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -17,63 +17,48 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
+import static org.springframework.boot.security.autoconfigure.web.servlet.PathRequest.toH2Console;
 import static org.springframework.boot.security.autoconfigure.web.servlet.PathRequest.toStaticResources;
 
-/**
- * Spring Security 설정 - JWT 기반 인증
- *
- * TODO: 개선 사항
- * - CORS 설정 추가
- * - 역할 기반 접근 제어 (ROLE_ADMIN, ROLE_USER)
- * - API 엔드포인트별 세밀한 권한 설정
- */
+
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
 
-    private final JwtAuthenticationFilter jwtAuthenticationFilter;
-
-    public SecurityConfig(JwtAuthenticationFilter jwtAuthenticationFilter) {
-        this.jwtAuthenticationFilter = jwtAuthenticationFilter;
-    }
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
-            // CSRF 비활성화 (JWT 사용 시 불필요)
-            .csrf(AbstractHttpConfigurer::disable)
+                // CSRF 비활성화 (JWT 사용 시 불필요)
+                .csrf(AbstractHttpConfigurer::disable)
 
-            // Session 사용 안 함 (Stateless)
-            .sessionManagement(session -> session
-                .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-            )
+                // Session 사용 안 함 (Stateless)
+                .sessionManagement(session -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+                // H2 Console 허용
+                .headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin))
 
-            // 요청 권한 설정
-            .authorizeHttpRequests(authorize -> authorize
-                     // 1) 정적 리소스
-                    .requestMatchers(toStaticResources().atCommonLocations()).permitAll()
+                // 요청 권한 설정
+                .authorizeHttpRequests(authorize -> authorize
+                                // 정적 리소스 (css, js, images 등) 허용
+                                .requestMatchers(toStaticResources().atCommonLocations()).permitAll()
+                                // H2 Console 허용
+                                .requestMatchers(toH2Console()).permitAll()
 
-                    // 2) 템플릿 페이지 렌더링
-                    .requestMatchers(HttpMethod.GET, "/").permitAll()
-                    .requestMatchers(HttpMethod.GET, "/pages/**").permitAll()
+                                // 템플릿 페이지 렌더링 허용 (html 파일)
+                                .requestMatchers(HttpMethod.GET, "/").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/pages/**").permitAll()
+                                
+                                // Public API 엔드포인트 허용
+                                .requestMatchers("/api/public/**").permitAll()
 
-                    // 3) 공개 API
-                    .requestMatchers(HttpMethod.GET, "/api/public/**").permitAll()
+                        // 나머지 전부 인증 필요
+                        // .anyRequest().authenticated()
+                )
+        ;
 
-                    // 4) 인증 API
-                    .requestMatchers(HttpMethod.POST, "/api/auth/login", "/api/auth/register").permitAll()
-
-                    // 5) 그 외 API는 인증 필요
-                    .requestMatchers("/api/**").authenticated()
-
-                    // 6) 나머지 전부 인증 필요
-                    .anyRequest().authenticated()
-            )
-
-            // JWT 필터 추가
-            .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }
@@ -92,10 +77,10 @@ public class SecurityConfig {
     @Bean
     public UserDetailsService userDetailsService(PasswordEncoder passwordEncoder) {
         UserDetails admin = User.builder()
-            .username("admin@test.com")
-            .password(passwordEncoder.encode("admin"))
-            .roles("USER", "ADMIN")
-            .build();
+                .username("admin@test.com")
+                .password(passwordEncoder.encode("admin"))
+                .roles("USER", "ADMIN")
+                .build();
 
         return new InMemoryUserDetailsManager(admin);
     }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,32 @@
+# Local 프로파일 설정 (개발자 로컬 환경 - H2 인메모리 DB)
+spring:
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:testdb;MODE=MySQL
+    username: sa
+    password:
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        format_sql: false
+        show_sql: false
+    defer-datasource-initialization: true
+
+
+logging:
+  level:
+    com.example.paymentsystem: DEBUG
+    org.springframework.security: INFO
+    org:
+      hibernate:
+        SQL: debug
+        type:
+          descriptor:
+            sql: trace

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,22 +1,12 @@
 spring:
   application:
     name: payment-demo
+  profiles:
+    active: local
 
   # 클라이언트 API 계약 설정 파일 import
   config:
     import: optional:classpath:client-api-config.yml
-
-  thymeleaf:
-    cache: false
-    prefix: classpath:/templates/
-    suffix: .html
-    mode: HTML
-    encoding: UTF-8
-
-  security:
-    user:
-      name: demo
-      password: demo123
 
 server:
   port: 8080
@@ -39,15 +29,3 @@ jwt:
   token-validity-in-seconds: ${JWT_VALIDITY:86400}  # 24 hours
 
 
-# UI Branding Configuration
-app:
-  ui:
-    branding:
-      app-name: CommerceHub
-      tagline: 통합 커머스 플랫폼
-      logo-text: 🏪 CommerceHub
-
-logging:
-  level:
-    com.bootcamp.paymentdemo: DEBUG
-    org.springframework.security: INFO

--- a/src/main/resources/data-xxx.sql
+++ b/src/main/resources/data-xxx.sql
@@ -1,3 +1,5 @@
+-- 나중에 세팅 완료후 파일명 변경하세요. by tutor hong
+
 INSERT INTO products (id, name, price, stock) VALUES (1, '고양이모래1', 50000, 10);
 INSERT INTO products (id, name, price, stock) VALUES (2, '고양이모래2', 35000, 5);
 INSERT INTO products (id, name, price, stock) VALUES (3, '배변패드 10set', 40000, 20);

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="icon" type="image/x-icon" th:href="@{/favicon.ico}">
-    <title>홈 - Commerce Demo</title>
+    <title>홈 - 오조의마법사</title>
     <link rel="stylesheet" th:href="@{/css/style.css}">
     <script th:src="@{/js/cookie-util.js}"></script>
     <script th:src="@{/js/app-config.js}"></script>
@@ -17,7 +17,7 @@
     <!-- Navigation Bar -->
     <nav class="navbar">
         <div class="navbar-container">
-            <a href="/" class="navbar-brand">🏪 CommerceHub</a>
+            <a href="/" class="navbar-brand">🏪 오조의마법사</a>
             <ul class="navbar-nav">
                 <li><a href="/" class="nav-link active">홈</a></li>
                 <li><a href="/pages/shop" class="nav-link">상점</a></li>

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -4,24 +4,160 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="icon" type="image/x-icon" th:href="@{/favicon.ico}">
-    <title>로그인 - CommerceHub</title>
+    <title>로그인 - 오조의마법사</title>
     <link rel="stylesheet" th:href="@{/css/style.css}">
     <script th:src="@{/js/theme.js}"></script>
     <script th:src="@{/js/cookie-util.js}"></script>
     <script th:src="@{/js/app-config.js}"></script>
     <script th:src="@{/js/api-handler.js}"></script>
     <script th:src="@{/js/api-validator.js}"></script>
+    <style>
+        .login-page {
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 2rem 1.5rem;
+            background:
+                radial-gradient(circle at top left, rgba(255, 255, 255, 0.95), transparent 32%),
+                radial-gradient(circle at top right, rgba(255, 214, 230, 0.9), transparent 28%),
+                linear-gradient(135deg, #fff7fb 0%, #ffeaf4 45%, #ffd6e7 100%);
+        }
+
+        [data-theme="dark"] .login-page {
+            background:
+                radial-gradient(circle at top left, rgba(255, 255, 255, 0.08), transparent 30%),
+                radial-gradient(circle at top right, rgba(244, 114, 182, 0.18), transparent 25%),
+                linear-gradient(135deg, #2b1320 0%, #3f1b30 45%, #5a2440 100%);
+        }
+
+        .login-shell {
+            width: 100%;
+            max-width: 430px;
+        }
+
+        .login-brand {
+            text-align: center;
+            margin-bottom: 2rem;
+        }
+
+        .login-brand h1 {
+            font-size: 2.75rem;
+            margin-bottom: 0.6rem;
+            color: #c2185b;
+            text-shadow: 0 10px 30px rgba(255, 105, 180, 0.18);
+        }
+
+        [data-theme="dark"] .login-brand h1 {
+            color: #ffd1e6;
+        }
+
+        .login-brand p {
+            color: #9d4b73;
+            font-weight: 500;
+        }
+
+        [data-theme="dark"] .login-brand p {
+            color: #f5bdd8;
+        }
+
+        .login-card {
+            background: rgba(255, 255, 255, 0.78);
+            border: 1px solid rgba(255, 182, 211, 0.7);
+            box-shadow: 0 24px 60px rgba(214, 51, 132, 0.18);
+            backdrop-filter: blur(14px);
+        }
+
+        [data-theme="dark"] .login-card {
+            background: rgba(36, 18, 28, 0.88);
+            border-color: rgba(255, 182, 211, 0.22);
+            box-shadow: 0 24px 60px rgba(0, 0, 0, 0.38);
+        }
+
+        .login-title {
+            text-align: center;
+            color: #ad1457;
+        }
+
+        [data-theme="dark"] .login-title {
+            color: #ffd1e6;
+        }
+
+        .login-page .form-input {
+            background: rgba(255, 255, 255, 0.82);
+            border-color: #f6b2cc;
+        }
+
+        .login-page .form-input:focus {
+            border-color: #ec4899;
+            box-shadow: 0 0 0 4px rgba(236, 72, 153, 0.15);
+        }
+
+        [data-theme="dark"] .login-page .form-input {
+            background: rgba(255, 255, 255, 0.06);
+            border-color: rgba(255, 182, 211, 0.28);
+        }
+
+        .login-primary-btn {
+            background: linear-gradient(135deg, #ff6fae 0%, #ff4f9a 45%, #f72585 100%);
+            box-shadow: 0 14px 30px rgba(247, 37, 133, 0.28);
+        }
+
+        .login-primary-btn:hover:not(:disabled) {
+            background: linear-gradient(135deg, #ff5ca3 0%, #ff3f8f 45%, #e91e63 100%);
+        }
+
+        .login-outline-btn {
+            border-color: #f06292;
+            color: #d81b60;
+            background: rgba(255, 255, 255, 0.55);
+        }
+
+        .login-outline-btn:hover:not(:disabled) {
+            background: linear-gradient(135deg, #ff8fbd 0%, #f06292 100%);
+            border-color: #f06292;
+        }
+
+        [data-theme="dark"] .login-outline-btn {
+            color: #ffd1e6;
+            border-color: #ff8fbd;
+            background: rgba(255, 255, 255, 0.04);
+        }
+
+        .login-helper {
+            color: #8c4a68;
+        }
+
+        [data-theme="dark"] .login-helper {
+            color: #e7bdd0;
+        }
+
+        .login-divider {
+            margin-top: 2rem;
+            padding-top: 1.5rem;
+            border-top: 1px solid rgba(240, 120, 170, 0.28);
+        }
+
+        .login-theme-toggle {
+            background: rgba(255, 255, 255, 0.6);
+            box-shadow: 0 10px 24px rgba(214, 51, 132, 0.16);
+        }
+
+        [data-theme="dark"] .login-theme-toggle {
+            background: rgba(255, 255, 255, 0.08);
+        }
+    </style>
 </head>
 <body>
-    <div style="min-height: 100vh; display: flex; align-items: center; justify-content: center; background: var(--bg-secondary);">
-        <div style="width: 100%; max-width: 400px; padding: 2rem;">
-            <div style="text-align: center; margin-bottom: 2rem;">
-                <h1 style="font-size: 2.5rem; margin-bottom: 0.5rem;">🏪 CommerceHub</h1>
-                <p style="color: var(--text-secondary);">통합 커머스 플랫폼</p>
+    <div class="login-page">
+        <div class="login-shell">
+            <div class="login-brand">
+                <h1>🏪 오조의마법사</h1>
+                <p>5조 커머스 플랫폼</p>
             </div>
 
-            <div class="card">
-                <div class="card-header" style="text-align: center;">로그인</div>
+            <div class="card login-card">
+                <div class="card-header login-title">로그인</div>
                 <div class="card-body">
                     <div id="error-message" class="alert alert-danger" style="margin-bottom: 1rem; display: none;">
                         <strong>⚠️ 로그인 실패</strong><br>
@@ -38,19 +174,19 @@
                             <input type="password" id="password" class="form-input" placeholder="••••••••" required>
                         </div>
 
-                        <button type="submit" class="btn btn-primary" style="width: 100%;">로그인</button>
+                        <button type="submit" class="btn btn-primary login-primary-btn" style="width: 100%;">로그인</button>
                     </form>
 
                     <div style="margin-top: 1.5rem; text-align: center;">
-                        <p style="color: var(--text-secondary); margin-bottom: 1rem;">계정이 없으신가요?</p>
-                        <a href="/pages/register" class="btn btn-outline" style="width: 100%;">회원가입</a>
+                        <p class="login-helper" style="margin-bottom: 1rem;">계정이 없으신가요?</p>
+                        <a href="/pages/register" class="btn btn-outline login-outline-btn" style="width: 100%;">회원가입</a>
                     </div>
 
-                    <div style="margin-top: 2rem; padding-top: 1.5rem; border-top: 1px solid var(--border);">
-                        <p style="color: var(--text-secondary); font-size: 0.875rem; margin-bottom: 0.5rem;">
+                    <div class="login-divider">
+                        <p class="login-helper" style="font-size: 0.875rem; margin-bottom: 0.5rem;">
                             <strong>테스트 계정:</strong>
                         </p>
-                        <ul style="color: var(--text-secondary); font-size: 0.875rem; list-style: none; padding: 0;">
+                        <ul class="login-helper" style="font-size: 0.875rem; list-style: none; padding: 0;">
                             <li>📧 admin@test.com / admin</li>
                         </ul>
                     </div>
@@ -58,7 +194,7 @@
             </div>
 
             <div style="text-align: center; margin-top: 2rem;">
-                <button id="theme-toggle" class="theme-toggle" onclick="toggleTheme()">🌙</button>
+                <button id="theme-toggle" class="theme-toggle login-theme-toggle" onclick="toggleTheme()">🌙</button>
             </div>
         </div>
     </div>


### PR DESCRIPTION

## 📌 관련 이슈 
#11 

## 🛠 작업 내용
> 환경변수 사용 방식을 정리하고, `.env.example` 및 `README`에 설정 가이드를 추가했으며 로그인 페이지를 핑크 그라데이션 기반의 화사한 톤으로 개선했습니다.

## 💻 주요 변경사항
- `.env`에 `application.yml`에서 사용하는 환경변수 포맷을 정리했습니다.
- 주석이 포함된 `.env.example` 파일을 추가해 팀원이 쉽게 환경변수를 설정할 수 있도록 했습니다.
- `README.md`의 빠른 시작 및 설정 가이드에 `.env` 사용 방법과 주의사항을 추가했습니다.
- `login.html`의 스타일을 수정해 밝고 화사한 핑크 그라데이션 톤의 로그인 화면으로 개선했습니다.
- 다크 모드에서도 어색하지 않도록 로그인 페이지 전용 색상 스타일을 함께 보완했습니다.

## ✅ 체크리스트
- [ ] 로컬에서 정상 동작 확인
- [ ] 불필요한 코드/주석 제거
- [ ] 네이밍 컨벤션 준수


<img width="743" height="931" alt="image" src="https://github.com/user-attachments/assets/dc89c8ee-ec7b-4d1c-bc7e-57303265eb26" />

<img width="640" height="911" alt="image" src="https://github.com/user-attachments/assets/a6fe5471-19da-442c-af90-06e699085910" />

