### PR TITLE
[fix] 프론트 API 응답 검증/필드 매핑 불일치 해결 및 주문/상점 UI 라우팅 개선

### DIFF
--- a/src/main/java/com/bootcamp/paymentdemo/common/config/DataInitializer.java
+++ b/src/main/java/com/bootcamp/paymentdemo/common/config/DataInitializer.java
@@ -3,6 +3,9 @@ package com.bootcamp.paymentdemo.common.config;
 import com.bootcamp.paymentdemo.point.entity.MembershipGrade;
 import com.bootcamp.paymentdemo.point.entity.MembershipPolicy;
 import com.bootcamp.paymentdemo.point.repository.MembershipPolicyRepository;
+import com.bootcamp.paymentdemo.user.UserService;
+
+import com.bootcamp.paymentdemo.user.dto.SignupRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
@@ -18,10 +21,25 @@ import java.util.List;
 @RequiredArgsConstructor
 public class DataInitializer implements ApplicationRunner {
 
+    private final UserService userService;
     private final MembershipPolicyRepository membershipPolicyRepository;
 
     @Override
     public void run(ApplicationArguments args) {
+        // 프론트 로그인 페이지에 표시된 테스트 계정
+        String name = "권지원";
+        String email = "admin@test.com";
+        String password = "admin";
+
+
+        userService.signup(SignupRequest.builder()
+                        .name(name)
+                        .email(email)
+                        .phone("01012341234")
+                        .password(password)
+                .build());
+
+
         // MembershipPolicy 초기 데이터 삽입
         // 없으면 등급 갱신, 포인트 적립, 등급 정책 조회 API 동작 안 함
         // NORMAL(1%), VIP(5%), VVIP(10%)

--- a/src/main/java/com/bootcamp/paymentdemo/user/dto/SignupRequest.java
+++ b/src/main/java/com/bootcamp/paymentdemo/user/dto/SignupRequest.java
@@ -1,8 +1,12 @@
 package com.bootcamp.paymentdemo.user.dto;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@Builder
+@AllArgsConstructor
 public class SignupRequest {
     private String name;
     private String email;

--- a/src/main/resources/client-api-config.yml
+++ b/src/main/resources/client-api-config.yml
@@ -158,8 +158,8 @@ api:
     # product 단건조회 부분이 없음
 
     create-order:
-      url:
-      method:
+      url: /api/orders
+      method: POST
       description: 주문 생성 (총 금액은 서버에서 계산)
       request:
         fields:
@@ -170,23 +170,34 @@ api:
       response:
         body:
           fields:
-            - name: orderId
+            - name: orderUid
               type: string
               required: true
-              description: 생성된 주문 ID
-              usage: 주문 페이지 리다이렉트에 사용
-            - name: totalAmount
-              type: number
-              required: false
-              description: 서버에서 계산된 총 금액
+              description: 생성된 주문 UID
             - name: orderNumber
               type: string
+              required: true
+              description: 주문 번호
+            - name: totalAmount
+              type: number
+              required: true
+              description: 주문 금액
+            - name: usedPoint
+              type: number
               required: false
-              description: 생성된 주문 번호
+              description: 사용한 포인트
+            - name: finalAmount
+              type: number
+              required: false
+              description: 최종 결제 금액
+            - name: status
+              type: string
+              required: true
+              description: 주문 상태
 
     list-orders:
-      url:
-      method:
+      url: /api/orders
+      method: GET
       description: 주문 목록 조회 (현재 로그인한 사용자의 주문)
       response:
         body:

--- a/src/main/resources/client-api-config.yml
+++ b/src/main/resources/client-api-config.yml
@@ -48,14 +48,14 @@ api:
             description: "JWT 토큰 (Bearer {token} 형식)"
         body:
           fields:
-            - name: success
-              type: boolean
-              required: true
-              description: 로그인 성공 여부
             - name: email
               type: string
-              required: false
+              required: true
               description: 로그인한 사용자 이메일
+            - name: id
+              type: string
+              required: true
+              description: 사용자 ID
 
     register:
       url: /api/auth/signup
@@ -78,14 +78,26 @@ api:
       response:
         body:
           fields:
-            - name: success
-              type: boolean
+            - name: id
+              type: number
               required: true
-              description: 회원가입 성공 여부
-            - name: message
+              description: 사용자 ID
+            - name: name
+              type: string
+              required: true
+              description: 사용자 이름
+            - name: customerUid
               type: string
               required: false
-              description: 에러 메시지 (실패 시)
+              description: PortOne 고객 고유 식별자
+            - name: email
+              type: string
+              required: true
+              description: 사용자 이메일
+            - name: phone
+              type: string
+              required: true
+              description: 사용자 전화번호
 
     get-current-user:
       url: /api/auth/me
@@ -114,10 +126,6 @@ api:
               required: true
               description: 사용자 전화번호 (KG 이니시스 필수)
               usage: PortOne payment window customer.phoneNumber
-            - name: pointBalance
-              type: number
-              required: true
-              description: 현재 포인트 잔액
 
     # ========================================
     # 상품 & 주문 (Product & Order)
@@ -184,34 +192,18 @@ api:
         body:
           type: array
           items:
+            - name: orderUid
+              type: string
+              required: true
+              description: 주문 UID (서버에서 주문을 식별하는 키)
             - name: orderNumber
               type: string
               required: true
               description: 주문 번호 (사용자에게 보이는 주문 번호)
-            - name: orderId
-              type: string
-              required: true
-              description: 주문 ID (시스템 고유 식별자)
             - name: totalAmount
               type: number
               required: true
-              description: 주문 금액 (포인트 차감 전)
-            - name: usedPoints
-              type: number
-              required: false
-              description: 사용한 포인트
-            - name: finalAmount
-              type: number
-              required: false
-              description: 최종 결제 금액 (포인트 차감 후)
-            - name: earnedPoints
-              type: number
-              required: false
-              description: 적립된 포인트
-            - name: currency
-              type: string
-              required: true
-              description: 통화
+              description: 주문 금액
             - name: status
               type: string
               required: true
@@ -245,18 +237,14 @@ api:
       response:
         body:
           fields:
-            - name: success
-              type: boolean
-              required: true
-              description: 생성 성공 여부
             - name: paymentId
               type: string
               required: true
               description: 생성된 결제 ID (PortOne SDK에 전달할 ID)
-            - name: status
+            - name: paymentStatus
               type: string
-              required: false
-              description: 결제 상태 (PENDING)
+              required: true
+              description: 결제 상태 (e.g. PENDING)
 
     confirm-payment:
       url:

--- a/src/main/resources/static/js/api-validator.js
+++ b/src/main/resources/static/js/api-validator.js
@@ -11,6 +11,10 @@
  * @returns {boolean} 검증 성공 여부
  */
 function validateApiResponse(endpointKey, response, headers = null) {
+    // backend CommonResponse 래핑을 자동으로 제거하고 body만 검증한다.
+    // 예: { success, status, data, error, timestamp } -> data
+    const bodyToValidate = unwrapCommonResponse(response);
+
     // YML에서 로드한 계약 정보 가져오기
     const contract = window.APP_RUNTIME?.config?.api?.endpoints?.[endpointKey];
 
@@ -29,22 +33,20 @@ function validateApiResponse(endpointKey, response, headers = null) {
 
         // Array 타입 검증
         if (bodySchema.type === 'array') {
-            if (!Array.isArray(response)) {
-                errors.push(`응답이 배열이어야 하지만 ${typeof response} 타입입니다.`);
+            if (!Array.isArray(bodyToValidate)) {
+                errors.push(`응답이 배열이어야 하지만 ${typeof bodyToValidate} 타입입니다.`);
             } else if (bodySchema.items) {
                 // 배열 아이템 필드 검증 (첫 번째 아이템만 체크)
-                if (response.length > 0) {
+                if (bodyToValidate.length > 0) {
                     bodySchema.items.forEach(fieldDef => {
-                        validateField(response[0], fieldDef, errors, '배열 첫 번째 아이템');
+                        validateField(bodyToValidate[0], fieldDef, errors, '배열 첫 번째 아이템');
                     });
                 }
             }
         }
         // Object 타입 검증
         else if (bodySchema.fields) {
-            bodySchema.fields.forEach(fieldDef => {
-                validateField(response, fieldDef, errors);
-            });
+            bodySchema.fields.forEach(fieldDef => validateField(bodyToValidate, fieldDef, errors));
         }
     }
 
@@ -67,7 +69,7 @@ function validateApiResponse(endpointKey, response, headers = null) {
     // ========================================
     if (errors.length > 0) {
         const expectedFormat = buildExpectedFormatMessage(contract);
-        const howToFix = buildHowToFixMessage(endpointKey, errors, contract, response);
+        const howToFix = buildHowToFixMessage(endpointKey, errors, contract, bodyToValidate);
 
         // Console에 상세 정보 출력
         console.error('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
@@ -83,7 +85,7 @@ function validateApiResponse(endpointKey, response, headers = null) {
         console.error('');
         console.error(howToFix);
         console.error('');
-        console.error('실제 응답 데이터:', response);
+        console.error('실제 응답 데이터(검증대상):', bodyToValidate);
         console.error('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
 
         // 화면에 간단한 알림 표시
@@ -93,6 +95,24 @@ function validateApiResponse(endpointKey, response, headers = null) {
     }
 
     return true;
+}
+
+/**
+ * CommonResponse 래핑 제거 유틸
+ * @param {any} response
+ * @returns {any} 검증할 body (래핑 제거 시 response.data, 아니면 원본)
+ */
+function unwrapCommonResponse(response) {
+    // 배열은 CommonResponse로 보지 않는다.
+    if (!response || typeof response !== 'object' || Array.isArray(response)) return response;
+
+    // CommonResponse 패턴: { data, success, status, error, timestamp }
+    const looksLikeCommonResponse =
+        response.data !== undefined &&
+        (response.success !== undefined || response.status !== undefined) &&
+        'timestamp' in response;
+
+    return looksLikeCommonResponse ? response.data : response;
 }
 
 /**
@@ -267,7 +287,23 @@ function buildHowToFixMessage(endpointKey, errors, contract, response) {
     parts.push('');
 
     // 실제 응답 미리보기
-    if (response && Object.keys(response).length > 0) {
+    if (Array.isArray(response)) {
+        if (response.length > 0) {
+            parts.push('💡 실제 응답 (배열의 첫 번째 요소):');
+            const first = response[0];
+            const actualFields = first && typeof first === 'object' ? Object.keys(first).slice(0, 3) : [];
+            actualFields.forEach(field => {
+                const value = first[field];
+                const type = Array.isArray(value) ? 'array' : typeof value;
+                parts.push(`   "${field}": ${type}`);
+            });
+            if (first && typeof first === 'object' && Object.keys(first).length > 3) {
+                parts.push(`   ... (첫 요소 총 ${Object.keys(first).length}개 필드)`);
+            }
+        } else {
+            parts.push('💡 실제 응답 (배열): []');
+        }
+    } else if (response && Object.keys(response).length > 0) {
         parts.push('💡 실제 응답 (처음 3개 필드):');
         const actualFields = Object.keys(response).slice(0, 3);
         actualFields.forEach(field => {

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -227,7 +227,7 @@
                         errorMessage.style.display = 'block';
                     }
                 } else {
-                    errorText.textContent = result.data.message || '이메일 또는 비밀번호가 올바르지 않습니다.';
+                    errorText.textContent = result.data.error?.message || '이메일 또는 비밀번호가 올바르지 않습니다.';
                     errorMessage.style.display = 'block';
                 }
             } catch (error) {

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -28,7 +28,7 @@
                 <img src="/images/logos/main-logo.png" alt="Pay System">
             </h1>
         </div>
-        <p class="hover-hint">✨ 로고에 마우스를 올려 마법을 시작하세요! ✨</p>
+        <p class="hover-hint">✨ 로고를 클릭해 마법을 시작하세요! ✨</p>
         <p class="creators">Team 오조의 마법사 : 권지원, 김예은, 박소영, 정민교, 신현민</p>
     </div>
 
@@ -51,11 +51,11 @@
                     <form id="login-form" onsubmit="handleLogin(event)">
                         <div class="form-group">
                             <label class="form-label">이메일</label>
-                            <input type="email" id="login-email" class="form-input" placeholder="admin@test.com" required autofocus>
+                            <input type="email" id="login-email" class="form-input" placeholder="admin@test.com" required autofocus value="admin@test.com">
                         </div>
                         <div class="form-group">
                             <label class="form-label">비밀번호</label>
-                            <input type="password" id="login-password" class="form-input" placeholder="••••••••" required>
+                            <input type="password" id="login-password" class="form-input" placeholder="••••••••" required value="admin">
                         </div>
 
                         <button type="submit" class="login-primary-btn" style="width: 100%; margin-top: 1rem;">로그인</button>
@@ -140,10 +140,11 @@
             // Allow forms to render completely before measuring 
             setTimeout(updateSceneHeight, 50);
 
-            // 로고 호버 애니메이션
+            // 로고 클릭 이벤트
             const authBrandLogo = document.getElementById('mainBrandLogo');
             if(authBrandLogo) {
-                authBrandLogo.addEventListener('mouseenter', showAuth);
+                authBrandLogo.style.cursor = 'pointer';
+                authBrandLogo.addEventListener('click', showAuth);
             }
         });
 

--- a/src/main/resources/templates/orders.html
+++ b/src/main/resources/templates/orders.html
@@ -165,6 +165,16 @@
         let currentUser = null;
         let orders = [];
 
+        // backend CommonResponse 래핑 제거 유틸
+        function unwrapCommonResponse(response) {
+            if (!response || typeof response !== 'object' || Array.isArray(response)) return response;
+            const looksLikeCommonResponse =
+                response.data !== undefined &&
+                (response.success !== undefined || response.status !== undefined) &&
+                'timestamp' in response;
+            return looksLikeCommonResponse ? response.data : response;
+        }
+
         // API 목록 동적 생성
         async function populateApiList() {
             const apiListElement = document.getElementById('api-list-orders');
@@ -214,8 +224,8 @@
         // 사용자 정보 로드
         async function loadCurrentUser() {
             try {
-                currentUser = await makeApiRequest('get-current-user', {
-                });
+                const raw = await makeApiRequest('get-current-user', {});
+                currentUser = unwrapCommonResponse(raw);
 
                 if (!validateApiResponse('get-current-user', currentUser)) {
                     throw new Error('API 응답 형식이 올바르지 않습니다.');
@@ -233,8 +243,8 @@
             const emptyEl = document.getElementById('order-list-empty');
 
             try {
-                const result = await makeApiRequest('list-orders', {
-                });
+                const raw = await makeApiRequest('list-orders', {});
+                const result = unwrapCommonResponse(raw);
 
                 // YML 스키마 기반 자동 검증
                 if (!validateApiResponse('list-orders', result)) {
@@ -289,7 +299,7 @@
 
                 tr.innerHTML = `
                     <td style="padding: 0.75rem; font-weight: 600;">${order.orderNumber}</td>
-                    <td style="padding: 0.75rem; font-family: monospace; font-size: 0.875rem; color: var(--text-secondary);">${order.orderId}</td>
+                    <td style="padding: 0.75rem; font-family: monospace; font-size: 0.875rem; color: var(--text-secondary);">${order.orderUid}</td>
                     <td style="padding: 0.75rem;">
                         <div style="font-weight: 600;">${order.totalAmount.toLocaleString()}원</div>
                         ${usedPoints > 0 ? `<div style="font-size: 0.75rem; color: var(--text-secondary);">실결제: ${finalAmount.toLocaleString()}원</div>` : ''}
@@ -304,7 +314,7 @@
                     </td>
                     <td style="padding: 0.75rem; text-align: center;">
                         ${order.status === 'PENDING' ?
-                            `<button class="btn btn-primary" style="padding: 0.5rem 1rem; font-size: 0.875rem;" onclick="payOrder('${order.orderId}', ${finalAmount})">
+                            `<button class="btn btn-primary" style="padding: 0.5rem 1rem; font-size: 0.875rem;" onclick="payOrder('${order.orderUid}', ${finalAmount})">
                                 💳 결제하기
                             </button>` :
                             `<span style="color: var(--text-secondary); font-size: 0.875rem;">-</span>`
@@ -324,7 +334,7 @@
             }
 
             // 해당 주문 찾기
-            const order = orders.find(o => o.orderId === orderId);
+            const order = orders.find(o => o.orderUid === orderId);
             if (!order) {
                 showNotification('⚠️ 주문을 찾을 수 없습니다', 'error');
                 return;

--- a/src/main/resources/templates/orders.html
+++ b/src/main/resources/templates/orders.html
@@ -251,6 +251,15 @@
                     throw new Error('API 응답 형식이 올바르지 않습니다.');
                 }
 
+                if (!Array.isArray(result)) {
+                    orders = [];
+                    loadingEl.innerHTML = '';
+                    emptyEl.style.display = 'block';
+                    containerEl.style.display = 'none';
+                    showNotification('주문 목록 응답이 배열 형식이 아닙니다', 'error');
+                    return;
+                }
+
                 orders = result;
                 loadingEl.style.display = 'none';
 
@@ -271,6 +280,8 @@
             const tbody = document.getElementById('order-list-body');
             tbody.innerHTML = '';
 
+            if (!Array.isArray(orders)) return;
+
             orders.forEach(order => {
                 const tr = document.createElement('tr');
                 tr.style.borderBottom = '1px solid var(--border)';
@@ -279,9 +290,10 @@
                 const statusStyle = getStatusStyle(order.status);
 
                 // 포인트 정보 구성
-                const usedPoints = order.usedPoints || 0;
-                const earnedPoints = order.earnedPoints || 0;
-                const finalAmount = order.finalAmount || order.totalAmount;
+                const usedPoints = Number(order.usedPoints || 0) || 0;
+                const earnedPoints = Number(order.earnedPoints || 0) || 0;
+                const totalAmountNum = Number(order.totalAmount || 0) || 0;
+                const finalAmountNum = Number(order.finalAmount ?? order.totalAmount) || totalAmountNum;
 
                 let pointsDisplay = '';
                 if (usedPoints > 0 || earnedPoints > 0) {
@@ -301,8 +313,8 @@
                     <td style="padding: 0.75rem; font-weight: 600;">${order.orderNumber}</td>
                     <td style="padding: 0.75rem; font-family: monospace; font-size: 0.875rem; color: var(--text-secondary);">${order.orderUid}</td>
                     <td style="padding: 0.75rem;">
-                        <div style="font-weight: 600;">${order.totalAmount.toLocaleString()}원</div>
-                        ${usedPoints > 0 ? `<div style="font-size: 0.75rem; color: var(--text-secondary);">실결제: ${finalAmount.toLocaleString()}원</div>` : ''}
+                        <div style="font-weight: 600;">${totalAmountNum.toLocaleString()}원</div>
+                        ${usedPoints > 0 ? `<div style="font-size: 0.75rem; color: var(--text-secondary);">실결제: ${finalAmountNum.toLocaleString()}원</div>` : ''}
                     </td>
                     <td style="padding: 0.75rem;">
                         ${pointsDisplay}
@@ -314,7 +326,7 @@
                     </td>
                     <td style="padding: 0.75rem; text-align: center;">
                         ${order.status === 'PENDING' ?
-                            `<button class="btn btn-primary" style="padding: 0.5rem 1rem; font-size: 0.875rem;" onclick="payOrder('${order.orderUid}', ${finalAmount})">
+                            `<button class="btn btn-primary" style="padding: 0.5rem 1rem; font-size: 0.875rem;" onclick="payOrder('${order.orderUid}', ${finalAmountNum})">
                                 💳 결제하기
                             </button>` :
                             `<span style="color: var(--text-secondary); font-size: 0.875rem;">-</span>`

--- a/src/main/resources/templates/orders.html
+++ b/src/main/resources/templates/orders.html
@@ -164,6 +164,16 @@
         // 현재 사용자 정보
         let currentUser = null;
         let orders = [];
+        let selectedOrderUid = null;
+
+        function getSelectedOrderUidFromQuery() {
+            try {
+                const params = new URLSearchParams(window.location.search);
+                return params.get('orderUid');
+            } catch (e) {
+                return null;
+            }
+        }
 
         // backend CommonResponse 래핑 제거 유틸
         function unwrapCommonResponse(response) {
@@ -216,6 +226,7 @@
             // API 목록 동적 생성 (비동기)
             populateApiList();
 
+            selectedOrderUid = getSelectedOrderUidFromQuery();
 
             await loadCurrentUser();
             await loadOrders();
@@ -263,6 +274,15 @@
                 orders = result;
                 loadingEl.style.display = 'none';
 
+                if (selectedOrderUid) {
+                    const matched = orders.find(o => o.orderUid === selectedOrderUid);
+                    if (matched) {
+                        orders = [matched];
+                    } else {
+                        showNotification('선택한 주문을 찾을 수 없습니다. 전체 목록을 표시합니다.', 'warning');
+                    }
+                }
+
                 if (orders.length === 0) {
                     emptyEl.style.display = 'block';
                 } else {
@@ -285,6 +305,10 @@
             orders.forEach(order => {
                 const tr = document.createElement('tr');
                 tr.style.borderBottom = '1px solid var(--border)';
+
+                if (selectedOrderUid && order.orderUid === selectedOrderUid) {
+                    tr.style.background = 'rgba(59, 130, 246, 0.08)'; // 하이라이트
+                }
 
                 // 상태에 따른 스타일
                 const statusStyle = getStatusStyle(order.status);

--- a/src/main/resources/templates/register.html
+++ b/src/main/resources/templates/register.html
@@ -274,7 +274,7 @@
                     flipCard('login');
                     document.getElementById('register-form').reset();
                 } else {
-                    errorText.textContent = result.message || '회원가입에 실패했습니다.';
+                    errorText.textContent = result.error?.message || '회원가입에 실패했습니다.';
                     errorMessage.style.display = 'block';
                 }
             } catch (error) {

--- a/src/main/resources/templates/register.html
+++ b/src/main/resources/templates/register.html
@@ -28,7 +28,7 @@
                 <img src="/images/logos/main-logo.png" alt="Pay System">
             </h1>
         </div>
-        <p class="hover-hint">✨ 로고에 마우스를 올려 마법을 시작하세요! ✨</p>
+        <p class="hover-hint">✨ 로고를 클릭해 마법을 시작하세요! ✨</p>
         <p class="creators">Team 오조의 마법사 : 권지원, 김예은, 박소영, 정민교, 신현민</p>
     </div>
 
@@ -140,10 +140,11 @@
             // Allow forms to render completely before measuring 
             setTimeout(updateSceneHeight, 50);
 
-            // 로고 호버 애니메이션
+            // 로고 클릭 이벤트
             const authBrandLogo = document.getElementById('mainBrandLogo');
             if(authBrandLogo) {
-                authBrandLogo.addEventListener('mouseenter', showAuth);
+                authBrandLogo.style.cursor = 'pointer';
+                authBrandLogo.addEventListener('click', showAuth);
             }
         });
 

--- a/src/main/resources/templates/shop.html
+++ b/src/main/resources/templates/shop.html
@@ -101,11 +101,21 @@
         // 현재 사용자 정보 (서버에서 로드)
         let currentUser = null;
 
+    // backend CommonResponse 래핑 제거 유틸
+    function unwrapCommonResponse(response) {
+        if (!response || typeof response !== 'object' || Array.isArray(response)) return response;
+        const looksLikeCommonResponse =
+            response.data !== undefined &&
+            (response.success !== undefined || response.status !== undefined) &&
+            'timestamp' in response;
+        return looksLikeCommonResponse ? response.data : response;
+    }
+
         // 페이지 로드 시 사용자 정보 가져오기
         async function loadCurrentUser() {
             try {
-                currentUser = await makeApiRequest('get-current-user', {
-                });
+            const raw = await makeApiRequest('get-current-user', {});
+            currentUser = unwrapCommonResponse(raw);
 
                 // YML 스키마 기반 자동 검증
                 if (!validateApiResponse('get-current-user', currentUser)) {
@@ -120,8 +130,8 @@
         // API에서 상품 목록 로드 (구현 필수)
         async function loadProductsFromApi() {
             try {
-                const result = await makeApiRequest('list-products', {
-                });
+            const raw = await makeApiRequest('list-products', {});
+            const result = unwrapCommonResponse(raw);
 
                 // YML 스키마 기반 자동 검증
                 if (!validateApiResponse('list-products', result)) {

--- a/src/main/resources/templates/shop.html
+++ b/src/main/resources/templates/shop.html
@@ -319,20 +319,24 @@
             };
 
             try {
-                const result = await makeApiRequest('create-order', {
+                const raw = await makeApiRequest('create-order', {
                     body: orderData
                 });
 
                 // YML 스키마 기반 자동 검증
-                if (!validateApiResponse('create-order', result)) {
+                if (!validateApiResponse('create-order', raw)) {
                     throw new Error('API 응답 형식이 올바르지 않습니다.');
                 }
 
-                if (result.orderId) {
+                const result = unwrapCommonResponse(raw);
+
+                if (result && result.orderUid) {
                     showNotification('주문 생성 완료!', 'success');
                     setTimeout(() => {
-                        window.location.href = `/pages/orders?orderId=${result.orderId}`;
+                        window.location.href = `/pages/orders`;
                     }, 1000);
+                } else {
+                    showNotification('주문 생성은 되었지만 orderUid를 확인할 수 없습니다.', 'warning');
                 }
             } catch (error) {
                 console.error('Failed to create order:', error);


### PR DESCRIPTION
## 주요 변경 사항

이번 PR은 백엔드 수정 없이, 프론트에서 CommonResponse로 래핑된 API 응답을 올바르게 검증/사용하도록 수정하고, 주문/상점 페이지의 렌더링 및 라우팅이 정상 동작하도록 개선했습니다.

핵심 문제는 프론트의 api-validator.js가 응답 스키마와 실제 백엔드 DTO의 data 구조/필드명을 동일하게 가정하면서, CommonResponse 래핑 및 필드명 불일치로 인해 API 응답 형식 오류가 발생했던 점입니다. 또한 list-orders, create-order 계약의 url/method 및 응답 필드 구성이 비어 있어 주문목록 호출이 실패할 수 있었습니다.

## 테스트/검증 방법

로그인 페이지에서 로그인 시 더 이상 API 응답 형식 오류가 발생하지 않는지 확인
회원가입 페이지에서 회원가입 시 동일 에러가 없는지 확인
상점(shop.html)에서 상품 카드가 정상 렌더링되는지 확인
상점에서 주문 생성 클릭 시 orders.html로 자동 이동하고, 방금 생성한 주문이 바로 보이는지 확인
