### PR TITLE
[feat] PortOne 결제 플로우/주문-포인트 UI API 매핑 수정

### DIFF
--- a/src/main/resources/client-api-config.yml
+++ b/src/main/resources/client-api-config.yml
@@ -262,47 +262,59 @@ api:
       response:
         body:
           fields:
-            - name: success
-              type: boolean
-              required: true
-              description: 확정 성공 여부
             - name: orderId
               type: string
-              required: false
-              description: 주문 ID
+              required: true
+              description: 주문 UID
             - name: status
               type: string
-              required: false
-              description: 변경된 주문 상태
+              required: true
+              description: 결제 상태 (PaymentStatus)
 
     cancel-payment:
-      url:
-      method:
-      description: 결제 취소/환불 (PortOne 결제 취소 및 주문 상태 업데이트)
+      url: /api/refunds/{paymentId}
+      method: POST
+      description: 결제 취소/환불 (RefundController를 통해 환불 요청)
       pathParams:
-        - name:
-          description: 결제 ID
+        - name: paymentId
+          description: 환불할 결제의 DB ID (RefundController는 Long paymentId를 기대)
       request:
         fields:
           - name: reason
             type: string
-            required: false
-            description: 취소 사유
+            required: true
+            description: 환불 사유
       response:
         body:
           fields:
-            - name: success
-              type: boolean
+            - name: refundId
+              type: number
               required: true
-              description: 취소 성공 여부
-            - name: orderId
+              description: 환불 ID
+            - name: orderUid
               type: string
-              required: false
-              description: 주문 ID
-            - name: status
+              required: true
+              description: 주문 UID
+            - name: paymentUid
               type: string
-              required: false
-              description: 변경된 주문 상태
+              required: true
+              description: 결제 UID
+            - name: refundAmount
+              type: number
+              required: true
+              description: 환불 금액
+            - name: reason
+              type: string
+              required: true
+              description: 환불 사유
+            - name: refundStatus
+              type: string
+              required: true
+              description: 환불 상태
+            - name: refundedAt
+              type: string
+              required: true
+              description: 환불 처리 시각
 
     # ========================================
     # 포인트 & 멤버십 (Point & Membership)

--- a/src/main/resources/static/js/portone-sdk.js
+++ b/src/main/resources/static/js/portone-sdk.js
@@ -39,8 +39,8 @@ async function openPortOnePayment(paymentData) {
         // 1단계: 서버에 결제 시작 요청 (PENDING 상태로 DB 저장)
         console.log('1단계: 서버에 결제 시작 요청...');
         const createPaymentResult = await makeApiRequest('create-payment', {
+            pathParams: paymentData.orderId,
             body: {
-                orderId: paymentData.orderId,
                 totalAmount: paymentData.totalAmount
             }
         });
@@ -55,7 +55,10 @@ async function openPortOnePayment(paymentData) {
         }
 
         // 서버에서 생성한 paymentId 사용
-        const serverPaymentId = createPaymentResult.paymentId;
+        const serverPaymentId = createPaymentResult?.data?.paymentId;
+        if (!serverPaymentId) {
+            throw new Error('결제 시작 응답에 paymentId가 없습니다.');
+        }
         console.log('서버에서 생성한 결제 ID:', serverPaymentId);
 
         // 2단계: PortOne 결제창 열기
@@ -142,10 +145,9 @@ async function openPortOnePaymentWithPoints(paymentData) {
         // 1단계: 서버에 결제 시작 요청 (PENDING 상태로 DB 저장, 포인트 포함)
         console.log('1단계: 서버에 결제 시작 요청 (포인트 포함)...');
         const createPaymentResult = await makeApiRequest('create-payment', {
+            pathParams: paymentData.orderId,
             body: {
-                orderId: paymentData.orderId,
-                totalAmount: paymentData.totalAmount,
-                pointsToUse: pointsToUse
+                totalAmount: paymentData.totalAmount
             }
         });
 
@@ -159,7 +161,10 @@ async function openPortOnePaymentWithPoints(paymentData) {
         }
 
         // 서버에서 생성한 paymentId 사용
-        const serverPaymentId = createPaymentResult.paymentId;
+        const serverPaymentId = createPaymentResult?.data?.paymentId;
+        if (!serverPaymentId) {
+            throw new Error('결제 시작 응답에 paymentId가 없습니다.');
+        }
         console.log('서버에서 생성한 결제 ID:', serverPaymentId);
 
         // 포인트 차감 후 최종 금액 계산

--- a/src/main/resources/templates/orders.html
+++ b/src/main/resources/templates/orders.html
@@ -417,10 +417,18 @@
             }
 
             try {
-                await confirmPaymentTemplate(paymentId);
+                const raw = await makeApiRequest('confirm-payment', {
+                    pathParams: paymentId
+                });
+                const data = unwrapCommonResponse(raw);
+
+                const orderId = data?.orderId ?? '-';
+                const status = data?.status ?? '-';
+                showNotification(`결제 확정 성공! (주문: ${orderId}, 상태: ${status})`, 'success');
                 await loadOrders(); // 주문 목록 새로고침
             } catch (error) {
                 console.error('Failed to confirm payment:', error);
+                showNotification('결제 확정 실패', 'error');
             }
         }
 
@@ -438,10 +446,21 @@
             }
 
             try {
-                await cancelPaymentTemplate(paymentId, 'Customer request');
+                const raw = await makeApiRequest('cancel-payment', {
+                    pathParams: paymentId,
+                    body: {
+                        reason: 'Customer request'
+                    }
+                });
+                const data = unwrapCommonResponse(raw);
+
+                const refundId = data?.refundId ?? '-';
+                const refundStatus = data?.refundStatus ?? '-';
+                showNotification(`환불 요청 성공! (환불ID: ${refundId}, 상태: ${refundStatus})`, 'success');
                 await loadOrders(); // 주문 목록 새로고침
             } catch (error) {
                 console.error('Failed to cancel payment:', error);
+                showNotification('환불 요청 실패', 'error');
             }
         }
 

--- a/src/main/resources/templates/points.html
+++ b/src/main/resources/templates/points.html
@@ -152,6 +152,62 @@
         let orders = [];
         let selectedOrder = null;
 
+        // backend CommonResponse 래핑 제거 유틸
+        function unwrapCommonResponse(response) {
+            if (!response || typeof response !== 'object' || Array.isArray(response)) return response;
+            const looksLikeCommonResponse =
+                response.data !== undefined &&
+                (response.success !== undefined || response.status !== undefined) &&
+                'timestamp' in response;
+            return looksLikeCommonResponse ? response.data : response;
+        }
+
+        // points 화면 내부에서 쓰는 필드/값으로 정규화
+        function normalizeOrderForPoints(order) {
+            const orderUid = String(order.orderUid ?? order.orderId ?? order.uid ?? '');
+            const orderNumber = String(order.orderNumber ?? order.orderNo ?? '');
+
+            // totalAmount vs totalPrice 등 필드명 불일치 대응
+            const rawTotal = order.totalAmount ?? order.totalPrice ?? order.paymentPrice ?? 0;
+            const totalAmount = Number(rawTotal) || 0;
+
+            // 상태 값 매핑 (백엔드 enum(PENDING/PAID) 또는 한글 상태 문자열)
+            const rawStatus = order.status ?? order.orderStatus ?? order.orderState ?? '';
+            const normalizedStatus = normalizeOrderStatus(rawStatus);
+
+            const createdAt = String(
+                order.createdAt ?? order.orderedCreatedAt ?? order.created_at ?? new Date().toISOString()
+            );
+
+            return {
+                // paymentData(orderId)로 넘길 값이 controller가 기대하는 orderUid 여야 함
+                orderUid: orderUid,
+                orderId: orderUid,
+                orderNumber: orderNumber,
+                totalAmount: totalAmount,
+                status: normalizedStatus,
+                createdAt: createdAt
+            };
+        }
+
+        function normalizeOrderStatus(rawStatus) {
+            if (!rawStatus) return 'PENDING';
+            const s = String(rawStatus).trim().toUpperCase();
+
+            // 이미 백엔드 enum 그대로 온 경우
+            if (['PENDING', 'PAID', 'CANCELLED', 'SHIPPED', 'DELIVERED'].includes(s)) return s;
+
+            // 한글 상태 대응
+            if (s === '결제 대기'.toUpperCase()) return 'PENDING';
+            if (s === '결제 완료'.toUpperCase()) return 'PAID';
+            if (s === '취소됨'.toUpperCase()) return 'CANCELLED';
+            if (s === '배송중'.toUpperCase()) return 'SHIPPED';
+            if (s === '배송 완료'.toUpperCase()) return 'DELIVERED';
+
+            // 알 수 없으면 기본을 PENDING으로 두되, 화면에서 걸러지지 않게 함
+            return 'PENDING';
+        }
+
         // API 목록 동적 생성
         async function populateApiList() {
             const apiListElement = document.getElementById('api-list-points');
@@ -203,8 +259,8 @@
         // 사용자 정보 로드
         async function loadCurrentUser() {
             try {
-                currentUser = await makeApiRequest('get-current-user', {
-                });
+                const raw = await makeApiRequest('get-current-user', {});
+                currentUser = unwrapCommonResponse(raw);
 
                 if (!validateApiResponse('get-current-user', currentUser)) {
                     throw new Error('API 응답 형식이 올바르지 않습니다.');
@@ -218,19 +274,27 @@
         // 주문 목록 로드
         async function loadOrders() {
             try {
-                const result = await makeApiRequest('list-orders', {
-                });
+                const raw = await makeApiRequest('list-orders', {});
+                const result = unwrapCommonResponse(raw);
 
-                if (!validateApiResponse('list-orders', result)) {
-                    return;
+                // data가 배열이거나, { orders: [...] } 형태일 수 있어 둘 다 대응
+                let ordersArray = [];
+                if (Array.isArray(result)) {
+                    ordersArray = result;
+                } else if (result && Array.isArray(result.orders)) {
+                    ordersArray = result.orders;
                 }
 
-                if (result && Array.isArray(result)) {
-                    orders = result;
-                    renderOrders();
-                } else {
-                    showNotification('주문 목록이 배열 형식이 아닙니다', 'error');
+                // 화면/결제용으로 정규화
+                const normalized = ordersArray.map(normalizeOrderForPoints);
+
+                if (!validateApiResponse('list-orders', normalized)) {
+                    // 스키마 불일치가 있어도 화면이 안 보이는 것보다는 "최소 렌더링"을 우선
+                    console.warn('[points] list-orders schema validation failed, rendering anyway.');
                 }
+
+                orders = normalized;
+                renderOrders();
             } catch (error) {
                 console.error('Failed to load orders:', error);
                 showNotification('주문 목록을 불러올 수 없습니다', 'error');
@@ -295,8 +359,8 @@
 
         // 포인트 모달 열기
         function openPointsModal(orderId) {
-            // orders 배열에서 orderId로 주문 찾기
-            const order = orders.find(o => o.orderId === orderId);
+            // orders 배열에서 orderUid/orderId로 주문 찾기
+            const order = orders.find(o => o.orderId === orderId || o.orderUid === orderId);
 
             if (!order) {
                 showNotification('주문을 찾을 수 없습니다', 'error');


### PR DESCRIPTION
## 주요 변경 사항

1. orders.html에서 결제 확정/취소 버튼이 의도한 백엔드 엔드포인트로 POST를 보내도록 요청/응답 처리를 정리했습니다.

2. points.html에서 list-orders 응답이 CommonResponse 및 data.orders 형태로 내려오는 경우에도 주문 목록이 렌더링되도록 프론트 로직을 수정했습니다.

3. portone-sdk.js에서 create-payment 요청 경로 파라미터 및 응답의 paymentId 파싱을 올바르게 수정했습니다.

4. client-api-config.yml에서 confirm-payment/cancel-payment 계약(경로/응답 스키마)을 백엔드 컨트롤러 스펙에 맞게 갱신했습니다.
