### PR TITLE
Feat: 주문 취소 기능 구현 #95

### DIFF
--- a/src/main/java/com/bootcamp/paymentdemo/order/controller/OrderController.java
+++ b/src/main/java/com/bootcamp/paymentdemo/order/controller/OrderController.java
@@ -90,4 +90,23 @@ public class OrderController {
         OrderConfirmResponse response = orderService.confirmOrder(userId, orderUid);
         return CommonResponseHandler.success(HttpStatus.OK, response);
     }
+
+//
+//         주문 취소
+//        PENDING 상태인 주문만 취소 가능
+//        -> 결제가 완료된 주문(PAID, CONFIRMED)은 취소 불가, 환불 프로세스로 진행해야 함
+//      - 본인 주문인지 서비스 레이어에서 검증
+//      - 반환값 없음 (취소 완료 여부만 200 OK로 응답)
+
+
+    @PatchMapping("/{orderUid}/cancel")
+    public ResponseEntity<CommonResponse<Void>> cancelOrder(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable String orderUid
+    ) {
+        Long userId = userDetails.getUserId();
+        // PENDING 상태 검증 및 CANCELLED 상태 전이는 서비스 레이어에서 처리
+        orderService.cancelOrder(userId, orderUid);
+        return CommonResponseHandler.success(HttpStatus.OK, null);
+    }
 }

--- a/src/main/java/com/bootcamp/paymentdemo/order/controller/OrderController.java
+++ b/src/main/java/com/bootcamp/paymentdemo/order/controller/OrderController.java
@@ -107,6 +107,6 @@ public class OrderController {
         Long userId = userDetails.getUserId();
         // PENDING 상태 검증 및 CANCELLED 상태 전이는 서비스 레이어에서 처리
         orderService.cancelOrder(userId, orderUid);
-        return CommonResponseHandler.success(HttpStatus.OK, null);
+        return CommonResponseHandler.success(HttpStatus.OK);
     }
 }

--- a/src/main/java/com/bootcamp/paymentdemo/order/dto/response/OrderListResponse.java
+++ b/src/main/java/com/bootcamp/paymentdemo/order/dto/response/OrderListResponse.java
@@ -6,6 +6,7 @@ public record OrderListResponse(
         String orderUid,
         String orderNumber,
         Long totalAmount,
+        Long usedPoint,
         String status,
         String createdAt
 ) {
@@ -14,6 +15,7 @@ public record OrderListResponse(
                 order.getOrderUid(),
                 order.getOrderNumber(),
                 order.getTotalAmount(),
+                order.getUsedPoint(),
                 order.getStatus().name(),
                 order.getCreatedAt().toString()
         );

--- a/src/main/java/com/bootcamp/paymentdemo/order/entity/Order.java
+++ b/src/main/java/com/bootcamp/paymentdemo/order/entity/Order.java
@@ -116,4 +116,20 @@ public class Order extends BaseEntity {
         }
         this.status = OrderStatus.REFUNDED;
     }
+
+//
+//      주문 취소
+//
+//      - PENDING 상태일 때만 취소 가능
+//        → 결제 전 단계이므로 사용자가 자유롭게 취소할 수 있음
+//      - PAID, CONFIRMED 상태에서는 취소 불가
+//        → 이미 결제가 완료된 주문은 환불 프로세스(PATCH /api/refunds)로 진행해야 함
+//      - 잘못된 상태에서 호출 시 INVALID_ORDER_STATUS 예외 발생
+
+    public void cancel() {
+        if (this.status != OrderStatus.PENDING) {
+            throw new ServiceException(ErrorCode.INVALID_ORDER_STATUS);
+        }
+        this.status = OrderStatus.CANCELLED;
+    }
 }

--- a/src/main/java/com/bootcamp/paymentdemo/order/enums/OrderStatus.java
+++ b/src/main/java/com/bootcamp/paymentdemo/order/enums/OrderStatus.java
@@ -1,9 +1,10 @@
 package com.bootcamp.paymentdemo.order.enums;
 
 public enum OrderStatus {
-    PENDING,
-    PAID,
-    CONFIRMED,
-    FAILED,
-    REFUNDED
+    PENDING,    // 주문 생성 후 결제 대기 중
+    PAID,       // 결제 완료 (PG사 결제 성공)
+    CONFIRMED,  // 주문 확정 (사용자 직접 확정 or 7일 경과 후 스케줄러 자동 확정)
+    FAILED,     // 결제 실패
+    REFUNDED,   // 환불 완료
+    CANCELLED   // 주문 취소 (PENDING 상태에서만 가능, 결제 완료 후에는 환불 프로세스로 진행)
 }

--- a/src/main/java/com/bootcamp/paymentdemo/order/service/OrderService.java
+++ b/src/main/java/com/bootcamp/paymentdemo/order/service/OrderService.java
@@ -133,6 +133,32 @@ public class OrderService {
         return OrderConfirmResponse.from(order);
     }
 
+//
+//      주문 취소
+//
+//      - PENDING 상태인 주문만 취소 가능
+//        → 결제 전 단계이므로 사용자가 자유롭게 취소할 수 있음
+//      - 본인 주문인지 검증 후 Order.cancel() 호출
+//        → PAID, CONFIRMED 상태에서 호출 시 INVALID_ORDER_STATUS 예외 발생
+//      - 취소 후 별도 반환값 없음 (204 No Content 대신 200 OK + null 반환)
+//
+//      @param userId   로그인한 유저 ID
+//      @param orderUid 취소할 주문 UID
+
+    @Transactional
+    public void cancelOrder(Long userId, String orderUid) {
+        Order order = orderRepository.findByOrderUid(orderUid)
+                .orElseThrow(() -> new ServiceException(ErrorCode.ORDER_NOT_FOUND));
+
+        // 본인 주문인지 확인
+        if (!order.getUserId().equals(userId)) {
+            throw new ServiceException(ErrorCode.ORDER_NOT_OWNED);
+        }
+
+        // 상태 전이 (PENDING → CANCELLED), 다른 상태면 예외 발생
+        order.cancel();
+    }
+
     // 소영 추가. Payment에서 사용하는 orderUid로 order 객체 검색하는 메서드
     public Order getOrderByOrderUid(String orderUid) {
         if (orderUid == null || orderUid.isBlank()) {


### PR DESCRIPTION
  ## 작업 설명
  사용자가 PENDING 상태의 주문을 직접 취소할 수 있는 기능 구현
  결제 완료 이후의 주문은 취소 불가하며 환불 프로세스로 진행

  ## 수락 기준
  - `OrderStatus` enum에 `CANCELLED` 추가
  - `Order.java` - `cancel()` 상태 전이 메서드 추가
  - `OrderService.java` - `cancelOrder()` 추가
  - `OrderController.java` - `PATCH /api/orders/{orderUid}/cancel` 추가

  ## 관련 이슈
  #95

  ## 추가 정보
  - PENDING 상태일 때만 취소 가능
  - PAID, CONFIRMED 상태에서는 취소 불가 → 환불 프로세스(PATCH /api/refunds)로 진행
  - 취소 성공 시 200 OK 반환 (별도 응답 바디 없음)