### PR TITLE
Feat: 7일 경과 PAID 주문 자동 CONFIRMED 전환 스케줄러 구현 #78

### DIFF
--- a/src/main/java/com/bootcamp/paymentdemo/order/entity/Order.java
+++ b/src/main/java/com/bootcamp/paymentdemo/order/entity/Order.java
@@ -110,8 +110,20 @@ public class Order extends BaseEntity {
         this.status = OrderStatus.FAILED;
     }
 
+//
+//      주문 환불 상태 전이
+//
+//      - 기존: CONFIRMED 상태일 때만 환불 가능
+//        -> 문제: 주문 확정 이후에도 환불이 가능해지는 잘못된 흐름
+//      - 변경: PAID 상태일 때만 환불 가능
+//        -> 올바른 흐름: 결제 완료(PAID) 후 7일 이내에만 환불 가능
+//        -> CONFIRMED(주문 확정) 이후에는 환불 불가
+//      - 잘못된 상태에서 호출 시 INVALID_ORDER_STATUS 예외 발생
+//
+
     public void refund() {
-        if (this.status != OrderStatus.CONFIRMED) {
+        // CONFIRMED → PAID 로 변경 (주문 확정 전, 결제 완료 상태에서만 환불 가능)
+        if (this.status != OrderStatus.PAID) {
             throw new ServiceException(ErrorCode.INVALID_ORDER_STATUS);
         }
         this.status = OrderStatus.REFUNDED;

--- a/src/main/java/com/bootcamp/paymentdemo/order/scheduler/OrderScheduler.java
+++ b/src/main/java/com/bootcamp/paymentdemo/order/scheduler/OrderScheduler.java
@@ -1,0 +1,79 @@
+package com.bootcamp.paymentdemo.order.scheduler;
+
+import com.bootcamp.paymentdemo.order.entity.Order;
+import com.bootcamp.paymentdemo.order.enums.OrderStatus;
+import com.bootcamp.paymentdemo.order.repository.OrderRepository;
+import com.bootcamp.paymentdemo.payment.entity.Payment;
+import com.bootcamp.paymentdemo.payment.service.PaymentService;
+import com.bootcamp.paymentdemo.point.service.UserPointService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+
+//  주문 자동 확정 스케줄러
+//
+//  - 결제 완료(PAID) 상태의 주문 중 7일이 경과한 주문을 매일 자정에 자동으로 CONFIRMED 전환
+//  - 환불 가능 기간(7일) 이 지난 주문은 사용자가 확정 버튼을 누르지 않아도 자동 확정
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OrderScheduler {
+
+    private final OrderRepository orderRepository;
+    private final PaymentService paymentService;
+    private final UserPointService userPointService;
+
+//
+//      7일 경과 PAID 주문 자동 확정
+//
+//      - 매일 자정(00:00:00) 실행
+//      - PAID 상태이면서 createdAt 기준 7일이 지난 주문 전체 조회
+//      - 각 주문을 CONFIRMED 로 상태 전이 후 포인트 적립
+//      - 처리 중 개별 주문에서 예외 발생 시 해당 주문만 스킵하고 나머지 계속 처리
+//        -> 한 건 실패가 전체 배치에 영향 주지 않도록 방어
+//
+    @Scheduled(cron = "0 0 0 * * *")  // 매일 자정 실행
+    @Transactional
+    public void autoConfirmOrders() {
+        // 현재 시각 기준 7일 전 시점 계산
+        LocalDateTime sevenDaysAgo = LocalDateTime.now().minusDays(7);
+
+        // PAID 상태이면서 7일 경과한 주문 목록 조회
+        List<Order> targets = orderRepository.findByStatusAndCreatedAtBefore(
+                OrderStatus.PAID, sevenDaysAgo
+        );
+
+        if (targets.isEmpty()) {
+            log.info("[OrderScheduler] 자동 확정 대상 주문 없음");
+            return;
+        }
+
+        log.info("[OrderScheduler] 자동 확정 대상 주문 수: {}", targets.size());
+
+        for (Order order : targets) {
+            try {
+                // 1. 주문 상태 PAID → CONFIRMED 전환
+                order.confirm();
+
+                // 2. 포인트 적립 (실제 PG 결제 금액 기준)
+                // finalAmount = totalAmount - pointToUse (포인트 차감 후 실제 결제 금액)
+                Payment payment = paymentService.getPaymentByOrderId(order.getId());
+                userPointService.earnPoint(order.getUserId(), order.getId(), payment.getFinalAmount());
+
+                log.info("[OrderScheduler] 주문 자동 확정 완료 - orderId: {}", order.getId());
+
+            } catch (Exception e) {
+                // 개별 주문 처리 실패 시 로그만 남기고 다음 주문 처리 계속 진행
+                log.error("[OrderScheduler] 주문 자동 확정 실패 - orderId: {}, error: {}",
+                        order.getId(), e.getMessage(), e);
+            }
+        }
+    }
+}

--- a/src/main/java/com/bootcamp/paymentdemo/order/service/OrderService.java
+++ b/src/main/java/com/bootcamp/paymentdemo/order/service/OrderService.java
@@ -13,6 +13,9 @@ import com.bootcamp.paymentdemo.order.entity.OrderItem;
 import com.bootcamp.paymentdemo.order.enums.OrderStatus;
 import com.bootcamp.paymentdemo.order.repository.OrderItemRepository;
 import com.bootcamp.paymentdemo.order.repository.OrderRepository;
+import com.bootcamp.paymentdemo.payment.entity.Payment;
+import com.bootcamp.paymentdemo.payment.respository.PaymentRepository;
+import com.bootcamp.paymentdemo.point.service.UserPointService;
 import com.bootcamp.paymentdemo.product.Product;
 import com.bootcamp.paymentdemo.product.ProductService;
 import lombok.RequiredArgsConstructor;
@@ -33,6 +36,12 @@ public class OrderService {
     private final OrderRepository orderRepository;
     private final OrderItemRepository orderItemRepository;
     private final ProductService productService;
+
+    // PaymentService 대신 PaymentRepository 직접 주입
+    // -> OrderService ↔ PaymentService 순환 참조 방지
+    // -> confirmOrder() 에서 finalAmount 조회 시에만 사용
+    private final PaymentRepository paymentRepository;
+    private final UserPointService userPointService;   //  주문 확정 시 포인트 적립용
 
     // 주문 생성
     @Transactional
@@ -127,9 +136,17 @@ public class OrderService {
 
         }
 
-        order.confirm(); //상태 전이 (PAID에서 CONFIRMED)
+        order.confirm(); // 상태 전이 (PAID → CONFIRMED)
 
-        // 추후 포인트팀 적립 트리거 (EDD 이벤트 발행하면 상호작 용 예정)
+
+        // 주문 확정 시 포인트 적립 (EDD 미사용, 직접 호출 방식)
+        // 적립 기준: 실제 PG 결제 금액 (포인트 차감 후 finalAmount)
+        // 전액 포인트 결제 시 finalAmount = 0 → earnPoint() 내부에서 적립 없음 처리
+        // PaymentService 대신 PaymentRepository 직접 사용 (OrderService ↔ PaymentService 순환 참조 방지)
+        Payment payment = paymentRepository.findByOrderId(order.getId())
+                .orElseThrow(() -> new ServiceException(ErrorCode.PAYMENT_NOT_FOUND));
+        userPointService.earnPoint(userId, order.getId(), payment.getFinalAmount());
+
         return OrderConfirmResponse.from(order);
     }
 

--- a/src/main/java/com/bootcamp/paymentdemo/payment/respository/PaymentRepository.java
+++ b/src/main/java/com/bootcamp/paymentdemo/payment/respository/PaymentRepository.java
@@ -11,4 +11,9 @@ public interface PaymentRepository extends JpaRepository<Payment,Long> {
     boolean existsByOrderAndPaymentStatus(Order order, PaymentStatus paymentStatus);
 
     Optional<Payment> findByPaymentUid(String paymentUid);
+
+    // 민교가 추가함
+    // 주문 확정 시 포인트 적립을 위해 orderId로 결제 정보 조회
+    // → confirmOrder() 및 스케줄러에서 finalAmount(실제 PG 결제 금액) 가져올 때 사용
+    Optional<Payment> findByOrderId(Long orderId);
 }

--- a/src/main/java/com/bootcamp/paymentdemo/payment/service/PaymentService.java
+++ b/src/main/java/com/bootcamp/paymentdemo/payment/service/PaymentService.java
@@ -296,5 +296,21 @@ public class PaymentService {
     public Payment getPaymentById(String paymentUid) {
         return paymentRepository.findByPaymentUid(paymentUid)
                 .orElseThrow(() -> new ServiceException(ErrorCode.PAYMENT_NOT_FOUND));
-        }
     }
+
+    // 민교가 추가함
+//
+//      orderId로 결제 정보 조회
+//
+//      - 주문 확정 시 포인트 적립을 위해 finalAmount(실제 PG 결제 금액) 가져올 때 사용
+//      - confirmOrder() 및 OrderScheduler에서 호출
+//
+//      @param orderId 조회할 주문 ID
+//      @return 해당 주문의 Payment 객체
+
+
+        public Payment getPaymentByOrderId(Long orderId) {
+        return paymentRepository.findByOrderId(orderId)
+                .orElseThrow(() -> new ServiceException(ErrorCode.PAYMENT_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/bootcamp/paymentdemo/refund/service/RefundService.java
+++ b/src/main/java/com/bootcamp/paymentdemo/refund/service/RefundService.java
@@ -36,8 +36,12 @@ public class RefundService {
         if (payment.getPaymentStatus() != PaymentStatus.SUCCESS) {
             throw new ServiceException(ErrorCode.INVALID_PAYMENT_STATUS);
         }
+        // 민교가 수정함
         // 주문 상태 검증
-        if (order.getStatus() != OrderStatus.CONFIRMED) {
+        // - 기존: CONFIRMED 상태일 때만 환불 가능 → 주문 확정 이후에도 환불 가능해지는 잘못된 흐름
+        // - 변경: PAID 상태일 때만 환불 가능
+        //   → 결제 완료(PAID) 후 7일 이내에만 환불 가능, CONFIRMED 이후에는 환불 불가
+        if (order.getStatus() != OrderStatus.PAID) {
             throw new ServiceException(ErrorCode.INVALID_ORDER_STATUS);
         }
 


### PR DESCRIPTION
 ## 작업 설명
  PAID 상태의 주문 중 결제 완료 후 7일이 경과한 주문을
  스케줄러가 매일 자정 자동으로 CONFIRMED 상태로 전환하고 포인트 적립 처리
  사용자가 직접 확정 버튼을 누른 경우(confirmOrder)에도 동일하게 포인트 적립 처리

  ## 수락 기준
  - `OrderScheduler` 클래스 생성 (`@Scheduled` 매일 자정 실행)
  - PAID 상태 + createdAt 기준 7일 경과 주문 조회 후 CONFIRMED 전환
  - CONFIRMED 전환 후 포인트 직접 적립 처리 (`userPointService.earnPoint()`)
  - `OrderService.confirmOrder()` 에도 포인트 적립 로직 추가
  - `PaymentRepository.findByOrderId()` 추가
  - `PaymentService.getPaymentByOrderId()` 추가

  ## 관련 이슈
  #78

  ## 추가 정보

  ### EDD 미사용
  이벤트 발행 없이 `userPointService.earnPoint()` 직접 호출 방식으로 구현

  ### 순환 참조 해결 (중요)
  `OrderService`에서 `PaymentService`를 직접 주입하면
  `OrderService → PaymentService → OrderService` 순환 참조 발생
  이를 방지하기 위해 **`PaymentService` 대신 `PaymentRepository`를 직접 주입**하여 해결

  ### PaymentRepository 및 PaymentService 수정 (타 도메인 수정)
  순환 참조 해결 및 스케줄러 구현을 위해 결제 도메인 파일 2개 수정
  - `PaymentRepository` - `findByOrderId()` 추가
    → orderId로 결제 정보 조회, confirmOrder() 및 OrderScheduler에서 finalAmount 가져올 때 사용
  - `PaymentService` - `getPaymentByOrderId()` 추가
    → OrderScheduler에서 호출 (OrderService는 순환 참조로 인해 PaymentRepository 직접 사용)
