### PR TITLE
Fix: OrderItem productId String 타입을 Product 연관관계로 변경 #101

### DIFF
--- a/src/main/java/com/bootcamp/paymentdemo/order/dto/response/OrderItemResponse.java
+++ b/src/main/java/com/bootcamp/paymentdemo/order/dto/response/OrderItemResponse.java
@@ -3,14 +3,14 @@ package com.bootcamp.paymentdemo.order.dto.response;
 import com.bootcamp.paymentdemo.order.entity.OrderItem;
 
 public record OrderItemResponse(
-        String productId,
+        Long productId,    // String → Long 변경 (Product PK 타입에 맞춤, #101)
         String productName,
         Long price,
         int quantity
 ) {
     public static OrderItemResponse from(OrderItem item) {
         return new OrderItemResponse(
-                item.getProductId(),
+                item.getProduct().getId(),  // getProductId() -> getProduct().getId() 변경 (#101)
                 item.getProductName(),
                 item.getPrice(),
                 item.getQuantity()

--- a/src/main/java/com/bootcamp/paymentdemo/order/entity/OrderItem.java
+++ b/src/main/java/com/bootcamp/paymentdemo/order/entity/OrderItem.java
@@ -1,6 +1,7 @@
 package com.bootcamp.paymentdemo.order.entity;
 
 import com.bootcamp.paymentdemo.common.BaseEntity;
+import com.bootcamp.paymentdemo.product.Product;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -14,38 +15,63 @@ public class OrderItem extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    // 어떤 주문에 속한 상품인지 → Order와 FK 연관관계
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "order_id", nullable = false)
     private Order order;
 
-    @Column(nullable = false)
-    private String productId;
+    /**
+     * Product 엔티티와 @ManyToOne 연관관계로 변경 (#101)
+     *
+     * - 기존: String productId → Product 테이블과 FK 관계 없음, 타입 불일치 (Long PK를 String으로 저장)
+     * - 변경: Product 객체 직접 참조 → FK 제약 조건 적용, 존재하지 않는 상품 저장 방지
+     * - Order ↔ OrderItem 과 동일한 방식으로 연관관계 적용
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id", nullable = false)
+    private Product product;
 
+    // 주문 시점의 상품명 스냅샷
+    // → 추후 상품명이 변경되어도 주문 당시 상품명을 보존하기 위해 별도 컬럼으로 저장
     @Column(nullable = false)
     private String productName;
 
+    // 주문 시점의 상품 가격 스냅샷
+    // → 추후 상품 가격이 변경되어도 주문 당시 가격을 보존하기 위해 별도 컬럼으로 저장
     @Column(nullable = false)
     private Long price;
 
     @Column(nullable = false)
     private int quantity;
 
-
     @Builder
-    private OrderItem(Order order, String productId,
+    private OrderItem(Order order, Product product,
                       String productName, Long price, int quantity) {
         this.order = order;
-        this.productId = productId;
+        this.product = product;
         this.productName = productName;
         this.price = price;
         this.quantity = quantity;
     }
-    //정적 팩토리 메서드
-    public static OrderItem create(Order order, String productId,
+
+    /**
+     * OrderItem 정적 팩토리 메서드
+     *
+     * - String productId 파라미터 제거, Product 객체 직접 받도록 변경 (#101)
+     * - productName, price는 주문 시점 스냅샷으로 별도 저장
+     *   → 상품 정보가 변경되어도 주문 내역은 당시 정보 유지
+     *
+     * @param order       소속 주문
+     * @param product     주문한 상품 엔티티
+     * @param productName 주문 시점 상품명 스냅샷
+     * @param price       주문 시점 가격 스냅샷
+     * @param quantity    주문 수량
+     */
+    public static OrderItem create(Order order, Product product,
                                    String productName, Long price, int quantity) {
         return OrderItem.builder()
                 .order(order)
-                .productId(productId)
+                .product(product)
                 .productName(productName)
                 .price(price)
                 .quantity(quantity)

--- a/src/main/java/com/bootcamp/paymentdemo/order/service/OrderService.java
+++ b/src/main/java/com/bootcamp/paymentdemo/order/service/OrderService.java
@@ -65,9 +65,9 @@ public class OrderService {
 
             OrderItem orderItem = OrderItem.create(
                     order,
-                    orderItemRequest.getProductId(),
-                    product.getName(),   // 실제 상품명
-                    product.getPrice(),  // 실제 가격
+                    product,             // String productId 대신 Product 객체 직접 전달 (#101)
+                    product.getName(),   // 주문 시점 상품명 스냅샷
+                    product.getPrice(),  // 주문 시점 가격 스냅샷
                     orderItemRequest.getQuantity()
             );
             orderItemRepository.save(orderItem);

--- a/src/main/java/com/bootcamp/paymentdemo/product/ProductService.java
+++ b/src/main/java/com/bootcamp/paymentdemo/product/ProductService.java
@@ -46,7 +46,8 @@ public class ProductService {
     }
 
     public void isOrderItemEnough(OrderItem orderItem){
-        Product product = getProductById(Long.parseLong(orderItem.getProductId()));
+        // getProductId() → getProduct().getId() 변경 (#101 - OrderItem Product 연관관계 변경)
+        Product product = getProductById(orderItem.getProduct().getId());
 
         if (orderItem.getQuantity() >= product.getStock()){
             throw new ServiceException(ErrorCode.STOCK_NOT_ENOUGH);
@@ -65,8 +66,9 @@ public class ProductService {
     @Transactional
     public void decreaseStockByOrder(Order order) {
         for (OrderItem orderItem : order.getOrderItems()) {
-            // TODO : // 현재 order 엔티티쪽에서 productId가 String으로 되어 있습니다. 이부분은 Long으로 바꾸는게 좋아보입니다.
-            Product product = productRepository.findByIdForUpdate(Long.valueOf(orderItem.getProductId()));
+            // getProductId() -> getProduct().getId() 변경 (#101 - OrderItem Product 연관관계 변경)
+            // String -> Long 변환 불필요 (Product 객체에서 직접 ID 조회)
+            Product product = productRepository.findByIdForUpdate(orderItem.getProduct().getId());
             product.decreaseStock(orderItem.getQuantity());
         }
     }


### PR DESCRIPTION
  ## 작업 설명
  OrderItem에서 Product를 단순 String productId로 저장하던 방식을
  Product 엔티티와 @ManyToOne 연관관계로 변경
  Product 테이블과 FK 관계가 없고 타입 불일치(Long PK를 String으로 저장)하는 문제 해결

  ## 수락 기준
  - `OrderItem.productId` String 필드 제거
  - `OrderItem` - `Product` @ManyToOne 연관관계 추가
  - `OrderItem.create()` 파라미터 수정 (String productId -> Product product)
  - `OrderService.createOrder()` 에서 Product 객체 전달하도록 수정
  - `OrderItemResponse.productId` String -> Long 타입 변경

  ## 관련 이슈
  #101

  ## 추가 정보
  - Order ↔ OrderItem 처럼 Product <-> OrderItem도 동일한 방식으로 연관관계 적용
  - productId는 Product의 PK(Long)인데 String으로 저장되어 타입 불일치 문제도 함께 해결

  ### ⚠️ 타 도메인 코드 수정 (중요)
  `OrderItem.getProductId()` 를 사용하던 타 도메인 파일 수정 필요
  `getProductId()` -> `getProduct().getId()` 로 변경

  - `ProductService.isOrderItemEnough()` - 49번째 줄 수정
  - `ProductService.decreaseStockByOrder()` - 70번째 줄 수정

  해당 메서드를 사용하는 팀원분들은 확인 부탁드립니다.