### PR TITLE
Fix: 주문 상세 조회 응답에 paymentUid 추가 #103

### DIFF
--- a/src/main/java/com/bootcamp/paymentdemo/order/dto/response/OrderDetailResponse.java
+++ b/src/main/java/com/bootcamp/paymentdemo/order/dto/response/OrderDetailResponse.java
@@ -9,9 +9,28 @@ public record OrderDetailResponse(
         Long totalAmount,
         String status,
         List<OrderItemResponse> items,
-        String createdAt
+        String createdAt,
+//
+//           결제 UID 추가
+//
+//          - PAID 상태일 때만 값이 존재, 그 외 상태(PENDING, CONFIRMED 등)는 null 반환
+//          - 프론트에서 paymentUid != null && status == PAID 조건으로 결제 취소 버튼 노출 여부 판단
+//          - 새로고침 후에도 주문 상세 조회 API를 통해 paymentUid를 다시 가져올 수 있어
+//            결제 취소 버튼이 유지됨
+//
+        String paymentUid
 ) {
-    public static OrderDetailResponse from(Order order) {
+//
+//      OrderDetailResponse 생성 팩토리 메서드
+//
+//      - paymentUid 파라미터 추가
+//        -> Service 레이어에서 PAID 상태 여부 확인 후 전달
+//        -> PAID 상태가 아니면 null 전달
+//
+//      @param order      주문 엔티티
+//      @param paymentUid PAID 상태일 때 결제 UID, 나머지는 null
+//
+    public static OrderDetailResponse from(Order order, String paymentUid) {
         return new OrderDetailResponse(
                 order.getOrderUid(),
                 order.getOrderNumber(),
@@ -20,7 +39,8 @@ public record OrderDetailResponse(
                 order.getOrderItems().stream()
                         .map(OrderItemResponse::from)
                         .toList(),
-                order.getCreatedAt().toString()
+                order.getCreatedAt().toString(),
+                paymentUid
         );
     }
 }

--- a/src/main/java/com/bootcamp/paymentdemo/order/service/OrderService.java
+++ b/src/main/java/com/bootcamp/paymentdemo/order/service/OrderService.java
@@ -109,7 +109,18 @@ public class OrderService {
         return PageResponse.from(page);
     }
 
-    // 주문 단건 조회
+//
+//      주문 단건 조회
+//
+//      - 본인 주문인지 검증 후 상세 정보 반환
+//      - PAID 상태일 때만 paymentUid 조회하여 응답에 포함 (#103)
+//        -> 프론트에서 paymentUid 존재 여부로 결제 취소 버튼 노출 판단
+//        -> 새로고침해도 API 재호출로 paymentUid 유지됨
+//      - PAID 외 상태(PENDING, CONFIRMED 등)는 paymentUid null 반환
+//
+//      @param userId   로그인한 유저 ID
+//      @param orderUid 조회할 주문 UID
+
     public OrderDetailResponse getOrderDetail(Long userId, String orderUid) {
         Order order = orderRepository.findByOrderUid(orderUid)
                 .orElseThrow(() ->
@@ -119,7 +130,18 @@ public class OrderService {
         if (!order.getUserId().equals(userId)){
             throw new ServiceException(ErrorCode.ORDER_NOT_OWNED);
         }
-        return OrderDetailResponse.from(order);
+
+        // PAID 상태일 때만 paymentUid 조회 (#103)
+        // -> 결제 취소 버튼 노출 여부를 프론트에서 판단할 수 있도록 paymentUid 제공
+        // -> 다른 상태에서는 불필요하므로 null 반환
+        String paymentUid = null;
+        if (order.getStatus() == OrderStatus.PAID) {
+            paymentUid = paymentRepository.findByOrderId(order.getId())
+                    .map(Payment::getPaymentUid)
+                    .orElse(null);
+        }
+
+        return OrderDetailResponse.from(order, paymentUid);
     }
 
     // 주문 확정


### PR DESCRIPTION
  ## 작업 설명
  주문 상세 조회 시 새로고침 후 결제 취소 버튼이 사라지는 문제 해결
  PAID 상태일 때 paymentUid를 응답에 포함하여 프론트에서 버튼 노출 여부를 판단할 수 있도록 수정

  ## 수락 기준
  - [ ] PAID 상태일 때 paymentUid가 응답에 포함된다
  - [ ] PAID 외 상태(PENDING, CONFIRMED 등)에서는 paymentUid가 null로 반환된다
  - [ ] 새로고침 후에도 주문 상세 API 재호출로 paymentUid가 유지된다

  ## 변경 내용

  ### OrderDetailResponse
  - paymentUid 필드 추가
  - from(Order) → from(Order, String paymentUid) 시그니처 변경

  ### OrderService.getOrderDetail()
  - PAID 상태일 때만 paymentRepository.findByOrderId()로 paymentUid 조회
  - 나머지 상태는 null 반환

  ## 관련 이슈
  closes #103

  ## 추가 정보
  - 프론트에서 paymentUid != null && status == PAID 조건으로 결제 취소 버튼 노출 여부 판단 가능
  - 새로고침해도 주문 상세 API 재호출로 paymentUid 유지됨