### PR TITLE
[fix] 장바구니 모달 포인트 사용 유저 플로우 변경

### DIFF
--- a/src/main/resources/static/js/portone-sdk.js
+++ b/src/main/resources/static/js/portone-sdk.js
@@ -126,17 +126,7 @@ async function openPortOnePayment(paymentData) {
  */
 async function openPortOnePaymentWithPoints(paymentData) {
     try {
-        const portoneConfig = await initPortOne();
-
-        // 일반결제: KG 이니시스 채널 키 사용 (고정)
-        const channelKeys = portoneConfig.channelKeys || {};
-        const channelKey = channelKeys['kg-inicis'];
-
-        if (!channelKey) {
-            throw new Error('kg-inicis 채널키가 설정되지 않았습니다.');
-        }
-
-        // 포인트 검증
+        // 포인트 검증 (PortOne 초기화보다 먼저: 0원 전액이면 SDK·채널키 불필요)
         const pointsToUse = paymentData.pointsToUse || 0;
         if (pointsToUse < 0) {
             throw new Error('포인트는 0 이상이어야 합니다.');
@@ -144,11 +134,13 @@ async function openPortOnePaymentWithPoints(paymentData) {
 
         // 1단계: 서버에 결제 시작 요청 (PENDING 상태로 DB 저장, 포인트 포함)
         console.log('1단계: 서버에 결제 시작 요청 (포인트 포함)...');
+        const createBody = { totalAmount: paymentData.totalAmount };
+        if (pointsToUse > 0) {
+            createBody.pointToUse = pointsToUse;
+        }
         const createPaymentResult = await makeApiRequest('create-payment', {
             pathParams: paymentData.orderId,
-            body: {
-                totalAmount: paymentData.totalAmount
-            }
+            body: createBody
         });
 
         // 서버 응답 검증
@@ -170,6 +162,31 @@ async function openPortOnePaymentWithPoints(paymentData) {
         // 포인트 차감 후 최종 금액 계산
         const finalAmount = Math.max(0, paymentData.totalAmount - pointsToUse);
         console.log(`포인트 차감: ${paymentData.totalAmount}원 - ${pointsToUse}P = ${finalAmount}원`);
+
+        // PG 청구 금액이 0원이면 PortOne 결제창을 열지 않음 (포인트 전액 결제)
+        if (finalAmount === 0) {
+            console.log('2단계: 최종 금액 0원 — PortOne SDK 생략, 서버 확정만 진행');
+            updateRequestDisplay({
+                paymentId: serverPaymentId,
+                totalAmount: 0,
+                note: '포인트 전액 결제 — PG 미사용'
+            });
+            updateEndpointDisplay('SKIP', 'PortOne.requestPayment() 생략 (finalAmount=0)');
+            displaySuccess({
+                paymentId: serverPaymentId,
+                pointsUsed: pointsToUse,
+                message: '포인트 전액 결제. 서버에서 확정하세요.'
+            });
+            return { paymentId: serverPaymentId, txId: null };
+        }
+
+        const portoneConfig = await initPortOne();
+        const channelKeys = portoneConfig.channelKeys || {};
+        const channelKey = channelKeys['kg-inicis'];
+
+        if (!channelKey) {
+            throw new Error('kg-inicis 채널키가 설정되지 않았습니다.');
+        }
 
         // 2단계: PortOne 결제창 열기
         console.log('2단계: PortOne 결제창 열기...');

--- a/src/main/resources/templates/layout.html
+++ b/src/main/resources/templates/layout.html
@@ -68,7 +68,7 @@
             <div id="cart-items" style="min-height: 100px;">
                 <p style="color: var(--text-secondary); text-align: center; padding: 2rem 0;">장바구니가 비어 있습니다.</p>
             </div>
-            
+
             <div class="cart-total" style="display: flex; justify-content: space-between; font-size: 1.5rem; font-weight: 700; margin-top: 1.5rem; color: var(--primary-dark); border-top: 2px solid var(--border); padding-top: 1rem;">
                 <span>총 주문 금액:</span>
                 <span id="cart-total">₩0</span>
@@ -81,7 +81,7 @@
                     <span style="font-size: 0.85rem; color: var(--text-secondary); background: var(--bg-tertiary); padding: 2px 8px; border-radius: 10px;">1000P 단위</span>
                 </div>
                 <div style="display: flex; gap: 0.5rem; align-items: stretch; margin-bottom: 0.5rem;">
-                    <input type="number" id="use-points" class="form-input" style="flex: 1; min-width: 0; font-size: 1.1rem; padding: 0.75rem;" 
+                    <input type="number" id="use-points" class="form-input" style="flex: 1; min-width: 0; font-size: 1.1rem; padding: 0.75rem;"
                            placeholder="사용할 포인트를 입력 (1000 단위)" min="0" step="1000" value="0"
                            onchange="validatePoints()" oninput="validatePoints()">
                     <button type="button" id="cart-full-points-btn" class="btn btn-outline" onclick="applyCartFullPointsToZero()"
@@ -91,7 +91,7 @@
                     </button>
                 </div>
                 <p id="cart-point-payment-hint" style="display: none; font-size: 0.85rem; color: var(--danger); margin-bottom: 1rem; line-height: 1.4;">
-                    최종 결제 금액이 1원~999원이 되지 않도록 포인트를 조정해 주세요. (0원 전액 또는 1,000원 이상만 가능)
+                    최종 결제 금액이 1000원 미만이 되지 않도록 포인트를 조정해 주세요.
                 </p>
             </div>
 
@@ -127,7 +127,7 @@
                     let ptData = ptRaw;
                     if (ptRaw.data && ptRaw.data.content) ptData = ptRaw.data.content;
                     else if (ptRaw.data) ptData = ptRaw.data;
-                    
+
                     if (ptData && ptData.currentPoint !== undefined) {
                         window.cartCurrentUser = { points: ptData.currentPoint };
                         const cp = document.getElementById('current-points');
@@ -156,7 +156,7 @@
             } else {
                 if (item) {
                     item.quantity = qty;
-                    if (productRef) item.stock = productRef.stock; 
+                    if (productRef) item.stock = productRef.stock;
                 } else if (productRef) {
                     window.globalCart[productId] = {
                         quantity: qty,
@@ -167,7 +167,7 @@
                     };
                 }
             }
-            
+
             localStorage.setItem('globalCart', JSON.stringify(window.globalCart));
             updateCartSummary();
             validatePoints();
@@ -180,7 +180,7 @@
                 const cartBtn = document.getElementById('nav-cart-btn');
                 if (cartBtn) {
                     cartBtn.classList.remove('cart-bounce');
-                    void cartBtn.offsetWidth; 
+                    void cartBtn.offsetWidth;
                     cartBtn.classList.add('cart-bounce');
                 }
             }
@@ -220,10 +220,10 @@
                 }
             });
 
-            cartItemsDiv.innerHTML = itemCount > 0 
-                ? html 
+            cartItemsDiv.innerHTML = itemCount > 0
+                ? html
                 : '<p style="color: var(--text-secondary); text-align: center; padding: 1rem 0;">장바구니가 비어 있습니다.</p>';
-                
+
             cartTotalSpan.textContent = `₩${total.toLocaleString()}`;
 
             const navCartCount = document.getElementById('nav-cart-count');
@@ -329,10 +329,10 @@
         window.validatePoints = function() {
             const useP = document.getElementById('use-points');
             if (!useP) return;
-            
+
             let val = parseInt(useP.value) || 0;
             let maxPoints = window.cartCurrentUser && window.cartCurrentUser.points !== undefined ? window.cartCurrentUser.points : 0;
-            
+
             let cartTotal = 0;
             Object.values(window.globalCart).forEach(item => {
                 cartTotal += item.price * item.quantity;
@@ -345,7 +345,7 @@
             if (val > cartTotal) {
                 val = Math.floor(cartTotal / 1000) * 1000;
             }
-            
+
             useP.value = Math.floor(val / 1000) * 1000;
             updateCartCheckoutButtonState();
         };
@@ -391,15 +391,15 @@
                      result = raw.data;
                      if(raw.data.content) result = raw.data.content;
                 }
-                
+
                 if (result && (result.orderUid || raw.success)) {
                     if (window.showNotification) window.showNotification('주문 생성 완료! 🛒', 'success');
-                    
+
                     window.globalCart = {};
                     localStorage.removeItem('globalCart');
                     updateCartSummary();
                     toggleCartModal();
-                    
+
                     setTimeout(() => { window.location.href = `/pages/orders`; }, 1000);
                 } else {
                     throw new Error('주문 생성 실패 응답');

--- a/src/main/resources/templates/layout.html
+++ b/src/main/resources/templates/layout.html
@@ -78,17 +78,28 @@
             <div class="point-usage" style="margin-top: 1.5rem; padding-top: 1rem; border-top: 1px dashed var(--border);">
                 <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 0.5rem;">
                     <label for="use-points" style="font-weight: bold; font-family: 'Gowun Dodum', sans-serif; font-size: 1.1rem; color: var(--text-primary);">💎 포인트 사용 (현재 <span id="current-points">0</span>P)</label>
-                    <span style="font-size: 0.85rem; color: var(--text-secondary); background: var(--bg-tertiary); padding: 2px 8px; border-radius: 10px;">100P 단위</span>
+                    <span style="font-size: 0.85rem; color: var(--text-secondary); background: var(--bg-tertiary); padding: 2px 8px; border-radius: 10px;">1000P 단위</span>
                 </div>
-                <input type="number" id="use-points" class="form-input" style="width: 100%; margin-bottom: 1.5rem; font-size: 1.1rem; padding: 0.75rem;" 
-                       placeholder="사용할 포인트를 입력 (100 단위)" min="0" step="100" value="0" onchange="validatePoints()">
+                <div style="display: flex; gap: 0.5rem; align-items: stretch; margin-bottom: 0.5rem;">
+                    <input type="number" id="use-points" class="form-input" style="flex: 1; min-width: 0; font-size: 1.1rem; padding: 0.75rem;" 
+                           placeholder="사용할 포인트를 입력 (1000 단위)" min="0" step="1000" value="0"
+                           onchange="validatePoints()" oninput="validatePoints()">
+                    <button type="button" id="cart-full-points-btn" class="btn btn-outline" onclick="applyCartFullPointsToZero()"
+                            style="white-space: nowrap; padding: 0.75rem 1rem; font-size: 0.95rem; font-family: 'Gowun Dodum', sans-serif;"
+                            title="보유 포인트로 총 결제 금액을 0원으로 맞춥니다 (주문 금액이 1000원 단위일 때)">
+                        전액 사용
+                    </button>
+                </div>
+                <p id="cart-point-payment-hint" style="display: none; font-size: 0.85rem; color: var(--danger); margin-bottom: 1rem; line-height: 1.4;">
+                    최종 결제 금액이 1원~999원이 되지 않도록 포인트를 조정해 주세요. (0원 전액 또는 1,000원 이상만 가능)
+                </p>
             </div>
 
             <div style="display: flex; gap: 1rem; margin-top: 1rem;">
                 <button class="btn btn-outline" onclick="toggleCartModal()" style="flex: 1; font-size: 1.1rem; padding: 1rem; font-family: 'Gowun Dodum', sans-serif;">
                     닫기
                 </button>
-                <button class="btn btn-primary" onclick="createOrder()" style="flex: 2; font-size: 1.15rem; padding: 1rem; font-family: 'Jua', sans-serif;">
+                <button type="button" id="cart-checkout-btn" class="btn btn-primary" onclick="createOrder()" style="flex: 2; font-size: 1.15rem; padding: 1rem; font-family: 'Jua', sans-serif;">
                     📦 주문 결제하기
                 </button>
             </div>
@@ -124,6 +135,7 @@
                     }
                 }
             } catch (e) { console.error('Failed to load points', e); }
+            if (typeof validatePoints === 'function') validatePoints();
         }
 
         window.updateQuantity = function(productId, delta, productRef) {
@@ -221,6 +233,97 @@
                 navCartCount.style.transform = 'scale(1.2)';
                 setTimeout(() => navCartCount.style.transform = 'scale(1)', 200);
             }
+
+            if (typeof updateCartCheckoutButtonState === 'function') updateCartCheckoutButtonState();
+        };
+
+        /** PG 최소(1,000원) 정책: 잔액이 0원이거나 1,000원 이상일 때만 결제 가능 */
+        window.isFinalAmountValidForPayment = function(orderTotal, usedPoints) {
+            const finalAmt = orderTotal - usedPoints;
+            if (finalAmt === 0) return true;
+            if (finalAmt >= 1000) return true;
+            return false;
+        };
+
+        window.updateCartCheckoutButtonState = function() {
+            const btn = document.getElementById('cart-checkout-btn');
+            const hint = document.getElementById('cart-point-payment-hint');
+            const fullBtn = document.getElementById('cart-full-points-btn');
+            if (!btn) return;
+
+            let cartTotal = 0;
+            let itemCount = 0;
+            Object.values(window.globalCart || {}).forEach(item => {
+                if (item.quantity > 0) {
+                    cartTotal += item.price * item.quantity;
+                    itemCount++;
+                }
+            });
+
+            const useP = document.getElementById('use-points');
+            const used = useP ? (parseInt(useP.value, 10) || 0) : 0;
+
+            const maxPoints = window.cartCurrentUser && window.cartCurrentUser.points !== undefined
+                ? window.cartCurrentUser.points
+                : 0;
+            const canFullToZero = itemCount > 0 && cartTotal > 0
+                && cartTotal % 1000 === 0
+                && maxPoints >= cartTotal;
+            if (fullBtn) {
+                fullBtn.disabled = !canFullToZero;
+                fullBtn.style.opacity = canFullToZero ? '1' : '0.45';
+            }
+
+            if (itemCount === 0 || cartTotal <= 0) {
+                btn.disabled = true;
+                if (hint) hint.style.display = 'none';
+                if (fullBtn) {
+                    fullBtn.disabled = true;
+                    fullBtn.style.opacity = '0.45';
+                }
+                return;
+            }
+
+            const ok = window.isFinalAmountValidForPayment(cartTotal, used);
+            btn.disabled = !ok;
+            if (hint) hint.style.display = ok ? 'none' : 'block';
+        };
+
+        /** 보유 포인트로 총 결제 금액을 0원으로 맞춤 (주문 금액이 1000원 단위이고 포인트가 충분할 때만) */
+        window.applyCartFullPointsToZero = function() {
+            const useP = document.getElementById('use-points');
+            if (!useP) return;
+
+            let cartTotal = 0;
+            Object.values(window.globalCart || {}).forEach(item => {
+                cartTotal += item.price * item.quantity;
+            });
+            const maxPoints = window.cartCurrentUser && window.cartCurrentUser.points !== undefined
+                ? window.cartCurrentUser.points
+                : 0;
+
+            if (cartTotal <= 0) {
+                if (window.showNotification) window.showNotification('장바구니가 비어 있습니다.', 'warning');
+                return;
+            }
+            if (maxPoints < cartTotal) {
+                if (window.showNotification) window.showNotification('보유 포인트가 주문 금액보다 적습니다.', 'warning');
+                return;
+            }
+            if (cartTotal % 1000 !== 0) {
+                if (window.showNotification) {
+                    window.showNotification('주문 금액이 1000원 단위일 때만 포인트로 0원까지 맞출 수 있습니다.', 'warning');
+                } else {
+                    alert('주문 금액이 1000원 단위일 때만 포인트로 0원까지 맞출 수 있습니다.');
+                }
+                return;
+            }
+
+            useP.value = cartTotal;
+            validatePoints();
+            if (window.showNotification) {
+                window.showNotification('포인트 전액 사용으로 최종 결제 금액을 0원으로 맞췄습니다.', 'success');
+            }
         };
 
         window.validatePoints = function() {
@@ -237,13 +340,14 @@
 
             if (val < 0) val = 0;
             if (val > maxPoints) {
-                val = Math.floor(maxPoints / 100) * 100;
+                val = Math.floor(maxPoints / 1000) * 1000;
             }
             if (val > cartTotal) {
-                val = Math.floor(cartTotal / 100) * 100;
+                val = Math.floor(cartTotal / 1000) * 1000;
             }
             
-            useP.value = Math.floor(val / 100) * 100;
+            useP.value = Math.floor(val / 1000) * 1000;
+            updateCartCheckoutButtonState();
         };
 
         window.createOrder = async function() {
@@ -263,6 +367,19 @@
 
             const usePointsInput = document.getElementById('use-points');
             const usedPoints = parseInt(usePointsInput.value) || 0;
+
+            let cartTotalForCheck = 0;
+            Object.values(window.globalCart).forEach(item => {
+                cartTotalForCheck += item.price * item.quantity;
+            });
+            if (!window.isFinalAmountValidForPayment(cartTotalForCheck, usedPoints)) {
+                if (window.showNotification) {
+                    window.showNotification('최종 결제 금액은 0원(포인트 전액)이거나 1,000원 이상이어야 합니다.', 'warning');
+                } else {
+                    alert('최종 결제 금액은 0원(포인트 전액)이거나 1,000원 이상이어야 합니다.');
+                }
+                return;
+            }
 
             const orderData = { items: items, usedPoint: usedPoints };
 

--- a/src/main/resources/templates/orders.html
+++ b/src/main/resources/templates/orders.html
@@ -253,7 +253,7 @@
                             </span>
                         </td>
                         <td style="padding: 0.75rem; text-align: center;">
-                        ${buildOrderActionButton(order, finalAmountNum)}
+                        ${buildOrderActionButton(order)}
                         </td>
                     `;
 
@@ -261,8 +261,9 @@
                 });
             }
 
-            // 주문 결제하기
-            async function payOrder(orderId, totalAmount) {
+            // 주문 결제하기 (POST /api/payments/{orderId} → paymentId → POST /api/payments/{paymentId}/confirm)
+            // totalAmount는 주문 총액, pointsToUse는 주문에 반영된 포인트(0원 전액 시에도 동일 플로우, PortOne SDK만 생략)
+            async function payOrder(orderId) {
                 if (!currentUser) {
                     showNotification('⚠️ 사용자 정보를 먼저 로드해주세요', 'warning');
                     return;
@@ -275,23 +276,26 @@
                     return;
                 }
 
+                const orderTotal = Number(order.totalAmount || 0) || 0;
+                const usedPoint = Number(order.usedPoint || 0) || 0;
+
                 try {
                     const paymentData = {
                         orderId: orderId,
-                        orderName: `주문 ${order.orderNumber}`,  // 주문 번호로 표시
-                        totalAmount: totalAmount,
+                        orderName: `주문 ${order.orderNumber}`,
+                        totalAmount: orderTotal,
+                        pointsToUse: usedPoint,
                         currency: 'KRW',
                         payMethod: 'CARD',
                         customer: {
-                            // PortOne은 customerId에 string 타입을 요구합니다.
                             customerId: String(currentUser.id),
                             fullName: currentUser.name,
-                            phoneNumber: currentUser.phone || '01012345678',  // KG 이니시스 필수
+                            phoneNumber: currentUser.phone || '01012345678',
                             email: currentUser.email
                         }
                     };
 
-                const result = await openPortOnePayment(paymentData);
+                const result = await openPortOnePaymentWithPoints(paymentData);
 
                 if (!result.paymentId) {
                     throw new Error('결제 결과에 paymentId가 없습니다.');
@@ -322,9 +326,9 @@
                 }
             }
 
-        function buildOrderActionButton(order, finalAmountNum) {
+        function buildOrderActionButton(order) {
             if (order.status === 'PENDING') {
-                return `<button class="btn btn-primary" style="padding: 0.5rem 1rem; font-size: 0.875rem;" onclick="payOrder('${order.orderUid}', ${finalAmountNum})">
+                return `<button class="btn btn-primary" style="padding: 0.5rem 1rem; font-size: 0.875rem;" onclick="payOrder('${order.orderUid}')">
                             💳 결제하기
                         </button>`;
             }

--- a/src/main/resources/templates/points.html
+++ b/src/main/resources/templates/points.html
@@ -71,9 +71,9 @@
                 </div>
                 <div style="margin-bottom: 1rem;">
                     <label for="points-input" style="display: block; margin-bottom: 0.5rem; font-weight: 600;">사용할 포인트</label>
-                    <input type="number" id="points-input" class="form-input" placeholder="0" min="0" step="100" value="0">
+                    <input type="number" id="points-input" class="form-input" placeholder="0" min="0" step="1000" value="0">
                     <p style="font-size: 0.875rem; color: var(--text-secondary); margin-top: 0.5rem;">
-                        💡 100P 단위로 사용 가능합니다
+                        💡 1000P 단위로 사용 가능합니다. 최종 금액은 0원(전액) 또는 1,000원 이상이어야 합니다.
                     </p>
                 </div>
                 <div style="margin-bottom: 1.5rem; padding: 1rem; background: var(--bg-secondary); border-radius: var(--radius-md);">
@@ -90,7 +90,10 @@
                         <span id="modal-final-amount" style="color: var(--primary);">-</span>
                     </div>
                 </div>
-                <button class="btn btn-primary" onclick="startPaymentWithPoints()" style="width: 100%;">
+                <p id="points-payment-hint" style="display: none; font-size: 0.875rem; color: var(--danger); margin-bottom: 1rem; line-height: 1.4;">
+                    최종 결제 금액이 1원~999원이 되지 않도록 포인트를 조정해 주세요. (0원 전액 또는 1,000원 이상만 가능)
+                </p>
+                <button type="button" id="btn-points-payment-start" class="btn btn-primary" onclick="startPaymentWithPoints()" style="width: 100%;">
                     💳 결제 시작
                 </button>
             </div>
@@ -212,7 +215,7 @@
             await loadCurrentUser();
             await loadOrders();
 
-            // 포인트 입력 변경 시 최종 금액 업데이트
+            // 포인트 입력 변경 시 최종 금액·결제 버튼 상태 업데이트
             document.getElementById('points-input').addEventListener('input', updateModalAmounts);
         });
 
@@ -347,6 +350,32 @@
             selectedOrder = null;
         }
 
+        /** PG 최소 금액 정책: 잔액 0원 또는 1,000원 이상만 허용 */
+        function isFinalAmountValidForPayment(orderTotal, usedPoints) {
+            const finalAmt = orderTotal - usedPoints;
+            if (finalAmt === 0) return true;
+            if (finalAmt >= 1000) return true;
+            return false;
+        }
+
+        function updatePointsModalPayButton() {
+            const btn = document.getElementById('btn-points-payment-start');
+            const hint = document.getElementById('points-payment-hint');
+            const finalSpan = document.getElementById('modal-final-amount');
+            if (!selectedOrder || !btn) return;
+
+            const points = parseInt(document.getElementById('points-input').value, 10) || 0;
+            const originalAmount = selectedOrder.totalAmount;
+            const finalAmount = Math.max(0, originalAmount - points);
+            const ok = isFinalAmountValidForPayment(originalAmount, points);
+
+            btn.disabled = !ok;
+            if (hint) hint.style.display = ok ? 'none' : 'block';
+            if (finalSpan) {
+                finalSpan.style.color = ok ? 'var(--primary)' : 'var(--danger)';
+            }
+        }
+
         // 모달 금액 업데이트
         function updateModalAmounts() {
             if (!selectedOrder) return;
@@ -358,6 +387,7 @@
             document.getElementById('modal-original-amount').textContent = originalAmount.toLocaleString() + '원';
             document.getElementById('modal-points-used').textContent = '- ' + points.toLocaleString() + 'P';
             document.getElementById('modal-final-amount').textContent = finalAmount.toLocaleString() + '원';
+            updatePointsModalPayButton();
         }
 
         // 결제 과정 표시 카드 표시/숨김
@@ -444,13 +474,18 @@
                 return;
             }
 
-            if (points % 100 !== 0) {
-                showNotification('포인트는 100P 단위로 사용 가능합니다', 'error');
+            if (points % 1000 !== 0) {
+                showNotification('포인트는 1000P 단위로 사용 가능합니다', 'error');
                 return;
             }
 
             if (points > selectedOrder.totalAmount) {
                 showNotification('사용 포인트가 주문 금액보다 클 수 없습니다', 'error');
+                return;
+            }
+
+            if (!isFinalAmountValidForPayment(selectedOrder.totalAmount, points)) {
+                showNotification('최종 결제 금액은 0원(포인트 전액)이거나 1,000원 이상이어야 합니다.', 'error');
                 return;
             }
 


### PR DESCRIPTION
1. 포인트는 1000원단위로 사용가능합니다. 다만 최종결제액이 1000원 미만인경우 주문할 수 없도록 UI에서 제한했습니다.
2. 만약 포인트가 넉넉할경우 1000원단위가 아니어도 '전액 사용' 버튼을 통해 최종결제액을 0원으로 만들도록 구현했습니다.
3. 최종결제액이 0원인 경우 포트원 결제창이 뜨지 않도록 수정했습니다.
4. 다만 이 과정에서도 API호출은 일반결제와 동일하게 호출되니 백엔드에서 0원 결제 분기를 처리해주세요 