### PR TITLE
Fix:CI/CD 빌드 시 JAR 파일 경로 인식 오류 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,6 +23,8 @@ jobs:
         run: |
           chmod +x gradlew
           ./gradlew clean bootJar -x test
+          echo " [빌드 파일 목록 확인]"
+          ls -R build/libs/
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -40,6 +42,8 @@ jobs:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
         run: |
+          echo " [도커 빌드 전 파일 확인]"
+          ls -l build/libs/*.jar || echo " 파일을 찾을 수 없습니다!"
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:latest .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
 


### PR DESCRIPTION
docker build 단계에서 build/libs 내의 JAR 파일을 찾지 못하는 문제를 해결하기 위해 deploy.yml에 경로 확인 로그를 추가하고 빌드 명령어를 보강함

close #138 