### PR TITLE
Fix: 도커 이미지 빌드 시 JAR 파일을 찾지 못하는 문제 해결

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM amazoncorretto:17-al2023-headless
 WORKDIR /app
-COPY ./build/libs/*.jar app.jar
+COPY build/libs/payment-demo-*.jar app.jar
 EXPOSE 8080
-ENTRYPOINT ["java", "-jar", "app.jar", "--server.address=0.0.0.0"]
+ENTRYPOINT ["java", "-jar", "app.jar", "--spring.profiles.active=prod", "--server.address=0.0.0.0"]


### PR DESCRIPTION
도커 이미지 빌드 시 JAR 파일을 찾지 못하는 문제 해결