### PR TITLE
Fix: GitHub Actions Gradle 빌드 실패 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,9 @@ jobs:
           java-version: '17'
           distribution: 'corretto'
 
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
       - name: Build with Gradle
         run: |
           chmod +x ./gradlew


### PR DESCRIPTION
**문제**
Setup Gradle 스텝 누락으로 Gradle wrapper 실행 실패
build/libs/ 디렉토리가 생성되지 않아 빌드 중단

**해결**
gradle/actions/setup-gradle@v4 스텝 추가

**변경파일**
.github/workflows/deploy.yml

close #142 