### PR TITLE
refactor: 포트원 환경별 분리

### DIFF
--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -23,6 +23,21 @@ spring:
       mode: always
       data-locations: classpath:data-xxx.sql
 
+
+# PortOne Configuration
+portone:
+  api:
+    base-url: https://api.portone.io
+    secret: ${PORTONE_API_SECRET:your-api-secret}
+  store:
+    id: ${PORTONE_STORE_ID:your-store-id}
+  channel:
+    kg-inicis: ${PORTONE_CHANNEL_KG:your-kg-inicis-channel-key}
+    toss: ${PORTONE_CHANNEL_TOSS:your-toss-channel-key}
+  webhook:
+    secret: ${PORTONE_WEBHOOK_SECRET:your-webhook-secret}
+
+
 logging:
   level:
     com.example.paymentsystem: DEBUG

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -11,7 +11,7 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: update # 나중에 validate로 변경 추천
       # update = 테이블 자동 생성/수정 (없으면 만들고, 있으면 유지)
     properties:
       hibernate:
@@ -21,3 +21,16 @@ spring:
     init:
       # MySQL에서는 H2 초기화 스크립트 실행 안 함
       mode: never
+
+# PortOne Configuration
+portone:
+  api:
+    base-url: https://api.portone.io
+    secret: ${PORTONE_API_SECRET}
+  store:
+    id: ${PORTONE_STORE_ID}
+  channel:
+    kg-inicis: ${PORTONE_CHANNEL_KG}
+    toss: ${PORTONE_CHANNEL_TOSS}
+  webhook:
+    secret: ${PORTONE_WEBHOOK_SECRET}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,22 +20,7 @@ spring:
       on-profile: prod
     import: optional:classpath:prod.yml
 
-# PortOne Configuration
-portone:
-  api:
-    base-url: https://api.portone.io
-    secret: ${PORTONE_API_SECRET:your-api-secret}
-  store:
-    id: ${PORTONE_STORE_ID:your-store-id}
-  channel:
-    kg-inicis: ${PORTONE_CHANNEL_KG:your-kg-inicis-channel-key}
-    toss: ${PORTONE_CHANNEL_TOSS:your-toss-channel-key}
-  webhook:
-    secret: ${PORTONE_WEBHOOK_SECRET:your-webhook-secret}
-
 # JWT Configuration
 jwt:
   secret: ${JWT_SECRET:commercehub-secret-key-for-demo-please-change-this-in-production-environment}
   token-validity-in-seconds: ${JWT_VALIDITY:86400}  # 24 hours
-
-


### PR DESCRIPTION
**변경사항**
- PortOne 설정을 application.yml에서 제거
- application-local.yml / application-prod.yml로 환경별 분리
- fallback 값 제거 (${VAR:default} → ${VAR})
- 민감 정보는 환경변수로만 관리하도록 변경

**참고**

EC2 컨테이너에서 아래 환경변수 정상 확인 완료:

- PORTONE_API_SECRET
- PORTONE_STORE_ID
- PORTONE_CHANNEL_KG
- PORTONE_WEBHOOK_SECRET
- DB_PASSWORD
- JWT_SECRET



close #150 