### PR TITLE
Fix: 멤버십 정책 수정

### DIFF
--- a/src/main/java/com/bootcamp/paymentdemo/common/config/DataInitializer.java
+++ b/src/main/java/com/bootcamp/paymentdemo/common/config/DataInitializer.java
@@ -63,9 +63,9 @@ public class DataInitializer implements ApplicationRunner {
         // NORMAL(1%), VIP(5%), VVIP(10%)
         if (membershipPolicyRepository.count() == 0) {
             membershipPolicyRepository.saveAll(List.of(
-                    MembershipPolicy.create(MembershipGrade.NORMAL, 0L, 50000L, 1),
-                    MembershipPolicy.create(MembershipGrade.VIP, 50001L, 100000L, 5),
-                    MembershipPolicy.create(MembershipGrade.VVIP, 100001L, null, 10)
+                    MembershipPolicy.create(MembershipGrade.NORMAL, 0L, 49999L, 1),
+                    MembershipPolicy.create(MembershipGrade.VIP, 50000L, 99999L, 5),
+                    MembershipPolicy.create(MembershipGrade.VVIP, 100000L, null, 10)
             ));
         }
     }

--- a/src/main/java/com/bootcamp/paymentdemo/point/dto/MembershipPolicyResponse.java
+++ b/src/main/java/com/bootcamp/paymentdemo/point/dto/MembershipPolicyResponse.java
@@ -12,7 +12,8 @@ public record MembershipPolicyResponse(
         return new MembershipPolicyResponse(
                 policy.getGrade(),
                 policy.getMinAmount(),
-                policy.getMaxAmount(),
+                // maxAmount: 49999 → 50000, 99999 → 100000, null 유지
+                policy.getMaxAmount() != null ? policy.getMaxAmount() + 1 : null,
                 policy.getPointRate()
         );
     }


### PR DESCRIPTION
**설명**
멤버십 등급 기준 금액 및 프론트 표시 방식 수정

- 백엔드 로직: 경계값 미만으로 처리
  - NORMAL: 0 ~ 49,999
  - VIP: 50,000 ~ 99,999
  - VVIP: 100,000 ~ 무제한

- 프론트 표시: 이상/이하로 표시
  - NORMAL: 0 ~ 5만원
  - VIP: 5만원 ~ 10만원
  - VVIP: 10만원 ~ 무제한


**변경사항**
- DataInitializer: 멤버십 정책 초기 데이터 기준 금액 수정
- MembershipPolicyResponse: 프론트 표시용 maxAmount 변환 처리 (+1)


close #118 